### PR TITLE
Fix provenance for publishing mcp-lite

### DIFF
--- a/.changeset/lazy-snails-bet.md
+++ b/.changeset/lazy-snails-bet.md
@@ -1,0 +1,5 @@
+---
+"mcp-lite": patch
+---
+
+Fix releases (internal fix)

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fiberplane/mcp.git"
+    "url": "git+https://github.com/fiberplane/mcp-lite.git"
   },
-  "homepage": "https://github.com/fiberplane/mcp",
+  "homepage": "https://github.com/fiberplane/mcp-lite",
   "scripts": {
     "build": "bun run --filter=* build",
     "typecheck": "bun run --filter=* typecheck",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,10 +2,10 @@
   "name": "mcp-lite",
   "type": "module",
   "version": "0.5.0",
-  "homepage": "https://github.com/fiberplane/mcp",
+  "homepage": "https://github.com/fiberplane/mcp-lite",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fiberplane/mcp.git",
+    "url": "git+https://github.com/fiberplane/mcp-lite.git",
     "directory": "packages/core"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update repo metadata to point to mcp-lite and add a changeset patch to fix releases.
> 
> - **Repository metadata**:
>   - Update `repository.url` and `homepage` from `fiberplane/mcp` to `fiberplane/mcp-lite` in `package.json` and `packages/core/package.json`.
> - **Release management**:
>   - Add changeset `.changeset/lazy-snails-bet.md` declaring a patch for `mcp-lite` (internal release fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12715900a704972aa7e6529341a6249196ffb831. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->