### PR TITLE
Support tool structured outputs

### DIFF
--- a/.changeset/sixty-coins-wonder.md
+++ b/.changeset/sixty-coins-wonder.md
@@ -1,0 +1,5 @@
+---
+"mcp-lite": minor
+---
+
+Support structured outputs in tool calls.

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -102,14 +102,14 @@ export function createContext(
       }
 
       // 2. Convert schema to JSON Schema if needed
-      const { mcpInputSchema } = resolveSchema(
+      const { resolvedSchema } = resolveSchema(
         params.schema,
         options.schemaAdapter,
       );
 
       // 3. Project to elicitation-compatible schema
       const requestedSchema = toElicitationRequestedSchema(
-        mcpInputSchema,
+        resolvedSchema,
         elicitOptions?.strict,
       );
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -16,7 +16,7 @@ import { JSON_RPC_ERROR_CODES } from "./types.js";
 import { isObject, objectWithKey } from "./utils.js";
 import {
   createValidationFunction,
-  resolveToolSchema,
+  resolveSchema,
   toElicitationRequestedSchema,
 } from "./validation.js";
 
@@ -102,7 +102,7 @@ export function createContext(
       }
 
       // 2. Convert schema to JSON Schema if needed
-      const { mcpInputSchema } = resolveToolSchema(
+      const { mcpInputSchema } = resolveSchema(
         params.schema,
         options.schemaAdapter,
       );

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -47,7 +47,11 @@ import {
 } from "./types.js";
 import { compileUriTemplate } from "./uri-template.js";
 import { errorToResponse, isObject, isString } from "./utils.js";
-import { extractArgumentsFromSchema, resolveToolSchema } from "./validation.js";
+import {
+  createValidationFunction,
+  extractArgumentsFromSchema,
+  resolveSchema,
+} from "./validation.js";
 
 async function runMiddlewares(
   middlewares: Middleware[],
@@ -384,6 +388,7 @@ export class McpServer {
    * and must return content in the ToolCallResult format.
    *
    * @template TArgs - Type of the tool's input arguments
+   * @template TOutput - Type of the structured content output
    * @param name - Unique tool name
    * @param def - Tool definition with schema, description, and handler
    * @returns This server instance for chaining
@@ -406,23 +411,31 @@ export class McpServer {
    * });
    * ```
    *
-   * @example With Standard Schema (Zod)
+   * @example With Standard Schema (Zod) - Full type inference
    * ```typescript
    * import { z } from "zod";
    *
-   * const schema = z.object({
-   *   message: z.string(),
-   *   count: z.number().optional()
+   * const inputSchema = z.object({
+   *   location: z.string()
    * });
    *
-   * server.tool("repeat", {
-   *   description: "Repeats a message",
-   *   inputSchema: schema,
-   *   handler: (args: { message: string; count?: number }) => ({
-   *     content: [{
-   *       type: "text",
-   *       text: args.message.repeat(args.count || 1)
-   *     }]
+   * const outputSchema = z.object({
+   *   temperature: z.number(),
+   *   conditions: z.string()
+   * });
+   *
+   * server.tool("getWeather", {
+   *   description: "Get weather for a location",
+   *   inputSchema,
+   *   outputSchema,
+   *   handler: (args) => ({
+   *     // args.location is typed as string ✅
+   *     content: [{ type: "text", text: "Weather data" }],
+   *     structuredContent: {
+   *       temperature: 22,
+   *       conditions: "sunny"
+   *       // Typed and validated! ✅
+   *     }
    *   })
    * });
    * ```
@@ -437,12 +450,30 @@ export class McpServer {
    * });
    * ```
    */
-  // Overload for StandardSchemaV1 with automatic type inference
+  // Overload 1: Both input and output are Standard Schema (full type inference)
+  tool<
+    SInput extends StandardSchemaV1<unknown, unknown>,
+    SOutput extends StandardSchemaV1<unknown, unknown>
+  >(
+    name: string,
+    def: {
+      description?: string;
+      inputSchema: SInput;
+      outputSchema: SOutput;
+      handler: (
+        args: InferOutput<SInput>,
+        ctx: MCPServerContext,
+      ) => Promise<ToolCallResult<InferOutput<SOutput>>> | ToolCallResult<InferOutput<SOutput>>;
+    },
+  ): this;
+
+  // Overload 2: Input is Standard Schema, output is JSON Schema or undefined
   tool<S extends StandardSchemaV1<unknown, unknown>>(
     name: string,
     def: {
       description?: string;
       inputSchema: S;
+      outputSchema?: unknown;
       handler: (
         args: InferOutput<S>,
         ctx: MCPServerContext,
@@ -450,16 +481,31 @@ export class McpServer {
     },
   ): this;
 
-  // Overload for JSON Schema or no schema (requires manual typing)
-  tool<TArgs = unknown>(
+  // Overload 3: Output is Standard Schema, input is JSON Schema or undefined
+  tool<S extends StandardSchemaV1<unknown, unknown>>(
     name: string,
     def: {
       description?: string;
       inputSchema?: unknown;
+      outputSchema: S;
+      handler: (
+        args: unknown,
+        ctx: MCPServerContext,
+      ) => Promise<ToolCallResult<InferOutput<S>>> | ToolCallResult<InferOutput<S>>;
+    },
+  ): this;
+
+  // Overload 4: JSON Schema or no schema (requires manual typing)
+  tool<TArgs = unknown, TOutput = unknown>(
+    name: string,
+    def: {
+      description?: string;
+      inputSchema?: unknown;
+      outputSchema?: unknown;
       handler: (
         args: TArgs,
         ctx: MCPServerContext,
-      ) => Promise<ToolCallResult> | ToolCallResult;
+      ) => Promise<ToolCallResult<TOutput>> | ToolCallResult<TOutput>;
     },
   ): this;
 
@@ -469,6 +515,7 @@ export class McpServer {
     def: {
       description?: string;
       inputSchema?: unknown | StandardSchemaV1<TArgs>;
+      outputSchema?: unknown | StandardSchemaV1<unknown>;
       handler: (
         args: TArgs,
         ctx: MCPServerContext,
@@ -479,8 +526,13 @@ export class McpServer {
       this.capabilities.tools = { listChanged: true };
     }
 
-    const { mcpInputSchema, validator } = resolveToolSchema(
+    const { mcpInputSchema, validator } = resolveSchema(
       def.inputSchema,
+      this.schemaAdapter,
+    );
+
+    const outputSchemaResolved = resolveSchema(
+      def.outputSchema,
       this.schemaAdapter,
     );
 
@@ -491,12 +543,16 @@ export class McpServer {
     if (def.description) {
       metadata.description = def.description;
     }
+    if (outputSchemaResolved.mcpInputSchema && def.outputSchema) {
+      metadata.outputSchema = outputSchemaResolved.mcpInputSchema;
+    }
 
     const entry: ToolEntry = {
       metadata,
       // TODO - We could avoid this cast if MethodHandler had a generic type for `params` that defaulted to unknown, but here we could pass TArgs
       handler: def.handler as MethodHandler,
       validator,
+      outputValidator: outputSchemaResolved.validator,
     };
     this.tools.set(name, entry);
     if (this.initialized) {
@@ -688,12 +744,12 @@ export class McpServer {
         argumentDefs = def.arguments as PromptArgumentDef[];
       } else {
         const { mcpInputSchema, validator: schemaValidator } =
-          resolveToolSchema(def.arguments, this.schemaAdapter);
+          resolveSchema(def.arguments, this.schemaAdapter);
         validator = schemaValidator;
         argumentDefs = extractArgumentsFromSchema(mcpInputSchema);
       }
     } else if (def.inputSchema) {
-      const { mcpInputSchema, validator: schemaValidator } = resolveToolSchema(
+      const { mcpInputSchema, validator: schemaValidator } = resolveSchema(
         def.inputSchema,
         this.schemaAdapter,
       );
@@ -1243,6 +1299,31 @@ export class McpServer {
     }
 
     const result = await entry.handler(validatedArgs, ctx);
+
+    // Validate structured content if outputSchema provided
+    if (
+      entry.outputValidator &&
+      (result as ToolCallResult).structuredContent &&
+      !(result as ToolCallResult).isError
+    ) {
+      try {
+        const validated = createValidationFunction(
+          entry.outputValidator,
+          (result as ToolCallResult).structuredContent,
+        );
+        (result as ToolCallResult).structuredContent = validated;
+      } catch (validationError) {
+        throw new RpcError(
+          JSON_RPC_ERROR_CODES.INVALID_PARAMS,
+          `Tool '${toolName}' returned invalid structured content: ${
+            validationError instanceof Error
+              ? validationError.message
+              : String(validationError)
+          }`,
+        );
+      }
+    }
+
     return result as ToolCallResult;
   }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -530,7 +530,7 @@ export class McpServer {
       this.capabilities.tools = { listChanged: true };
     }
 
-    const { mcpInputSchema, validator } = resolveSchema(
+    const { resolvedSchema, validator } = resolveSchema(
       def.inputSchema,
       this.schemaAdapter,
     );
@@ -542,13 +542,13 @@ export class McpServer {
 
     const metadata: Tool = {
       name,
-      inputSchema: mcpInputSchema,
+      inputSchema: resolvedSchema,
     };
     if (def.description) {
       metadata.description = def.description;
     }
-    if (outputSchemaResolved.mcpInputSchema && def.outputSchema) {
-      metadata.outputSchema = outputSchemaResolved.mcpInputSchema;
+    if (outputSchemaResolved.resolvedSchema && def.outputSchema) {
+      metadata.outputSchema = outputSchemaResolved.resolvedSchema;
     }
 
     const entry: ToolEntry = {
@@ -747,20 +747,20 @@ export class McpServer {
       if (Array.isArray(def.arguments)) {
         argumentDefs = def.arguments as PromptArgumentDef[];
       } else {
-        const { mcpInputSchema, validator: schemaValidator } = resolveSchema(
+        const { resolvedSchema, validator: schemaValidator } = resolveSchema(
           def.arguments,
           this.schemaAdapter,
         );
         validator = schemaValidator;
-        argumentDefs = extractArgumentsFromSchema(mcpInputSchema);
+        argumentDefs = extractArgumentsFromSchema(resolvedSchema);
       }
     } else if (def.inputSchema) {
-      const { mcpInputSchema, validator: schemaValidator } = resolveSchema(
+      const { resolvedSchema, validator: schemaValidator } = resolveSchema(
         def.inputSchema,
         this.schemaAdapter,
       );
       validator = schemaValidator;
-      argumentDefs = extractArgumentsFromSchema(mcpInputSchema);
+      argumentDefs = extractArgumentsFromSchema(resolvedSchema);
     }
 
     const metadata: PromptMetadata = {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1043,6 +1043,7 @@ export class McpServer {
           metadata: { ...entry.metadata, name: qualifiedName },
           handler: wrappedHandler,
           validator: entry.validator,
+          outputValidator: entry.outputValidator,
         };
 
         this.tools.set(qualifiedName, wrappedEntry);

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -453,7 +453,7 @@ export class McpServer {
   // Overload 1: Both input and output are Standard Schema (full type inference)
   tool<
     SInput extends StandardSchemaV1<unknown, unknown>,
-    SOutput extends StandardSchemaV1<unknown, unknown>
+    SOutput extends StandardSchemaV1<unknown, unknown>,
   >(
     name: string,
     def: {
@@ -463,7 +463,9 @@ export class McpServer {
       handler: (
         args: InferOutput<SInput>,
         ctx: MCPServerContext,
-      ) => Promise<ToolCallResult<InferOutput<SOutput>>> | ToolCallResult<InferOutput<SOutput>>;
+      ) =>
+        | Promise<ToolCallResult<InferOutput<SOutput>>>
+        | ToolCallResult<InferOutput<SOutput>>;
     },
   ): this;
 
@@ -491,7 +493,9 @@ export class McpServer {
       handler: (
         args: unknown,
         ctx: MCPServerContext,
-      ) => Promise<ToolCallResult<InferOutput<S>>> | ToolCallResult<InferOutput<S>>;
+      ) =>
+        | Promise<ToolCallResult<InferOutput<S>>>
+        | ToolCallResult<InferOutput<S>>;
     },
   ): this;
 
@@ -743,8 +747,10 @@ export class McpServer {
       if (Array.isArray(def.arguments)) {
         argumentDefs = def.arguments as PromptArgumentDef[];
       } else {
-        const { mcpInputSchema, validator: schemaValidator } =
-          resolveSchema(def.arguments, this.schemaAdapter);
+        const { mcpInputSchema, validator: schemaValidator } = resolveSchema(
+          def.arguments,
+          this.schemaAdapter,
+        );
         validator = schemaValidator;
         argumentDefs = extractArgumentsFromSchema(mcpInputSchema);
       }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1305,20 +1305,20 @@ export class McpServer {
       validatedArgs = ctx.validate(entry.validator, callParams.arguments);
     }
 
-    const result = await entry.handler(validatedArgs, ctx);
+    const result = (await entry.handler(validatedArgs, ctx)) as ToolCallResult;
 
     // Validate structured content if outputSchema provided
     if (
       entry.outputValidator &&
-      (result as ToolCallResult).structuredContent &&
-      !(result as ToolCallResult).isError
+      "structuredContent" in result &&
+      !result.isError
     ) {
       try {
         const validated = createValidationFunction(
           entry.outputValidator,
-          (result as ToolCallResult).structuredContent,
+          result.structuredContent,
         );
-        (result as ToolCallResult).structuredContent = validated;
+        result.structuredContent = validated;
       } catch (validationError) {
         throw new RpcError(
           JSON_RPC_ERROR_CODES.INVALID_PARAMS,
@@ -1331,7 +1331,7 @@ export class McpServer {
       }
     }
 
-    return result as ToolCallResult;
+    return result;
   }
 
   private async handlePromptsList(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -276,6 +276,7 @@ export interface Tool {
   name: string;
   description?: string;
   inputSchema: unknown;
+  outputSchema?: unknown;
 }
 
 export interface Prompt {
@@ -331,6 +332,7 @@ export interface ToolEntry {
   metadata: Tool;
   handler: MethodHandler;
   validator?: unknown;
+  outputValidator?: unknown;
 }
 
 export interface ResourceEntry {
@@ -442,9 +444,10 @@ export interface ResourceSubscribeParams {
   uri: string;
 }
 
-export interface ToolCallResult {
+export interface ToolCallResult<TStructuredContent = unknown> {
   content: Content[];
   isError?: boolean;
+  structuredContent?: TStructuredContent;
 }
 
 export interface PromptGetResult {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -2,7 +2,7 @@ import { RpcError } from "./errors.js";
 import type { PromptArgumentDef, SchemaAdapter } from "./types.js";
 import { isStandardSchema, JSON_RPC_ERROR_CODES } from "./types.js";
 
-export function resolveToolSchema(
+export function resolveSchema(
   inputSchema?: unknown,
   schemaAdapter?: SchemaAdapter,
 ): {
@@ -110,7 +110,7 @@ export function toElicitationRequestedSchema(
   // Handle Standard Schema inputs by converting to JSON Schema first
   if (isStandardSchema(schema)) {
     throw new Error(
-      "Standard Schema inputs must be converted via resolveToolSchema first",
+      "Standard Schema inputs must be converted via resolveSchema first",
     );
   }
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -3,28 +3,28 @@ import type { PromptArgumentDef, SchemaAdapter } from "./types.js";
 import { isStandardSchema, JSON_RPC_ERROR_CODES } from "./types.js";
 
 export function resolveSchema(
-  inputSchema?: unknown,
+  schema?: unknown,
   schemaAdapter?: SchemaAdapter,
 ): {
-  mcpInputSchema: unknown;
+  resolvedSchema: unknown;
   validator?: unknown;
 } {
-  if (!inputSchema) return { mcpInputSchema: { type: "object" } };
+  if (!schema) return { resolvedSchema: { type: "object" } };
 
-  if (isStandardSchema(inputSchema)) {
+  if (isStandardSchema(schema)) {
     if (!schemaAdapter) {
-      const vendor = inputSchema["~standard"].vendor;
+      const vendor = schema["~standard"].vendor;
       throw new Error(
         `Cannot use Standard Schema (vendor: "${vendor}") without a schema adapter. ` +
           `Configure a schema adapter when creating McpServer.`,
       );
     }
 
-    const jsonSchema = schemaAdapter(inputSchema);
-    return { mcpInputSchema: jsonSchema, validator: inputSchema };
+    const jsonSchema = schemaAdapter(schema);
+    return { resolvedSchema: jsonSchema, validator: schema };
   }
 
-  return { mcpInputSchema: inputSchema };
+  return { resolvedSchema: schema };
 }
 
 export function createValidationFunction<T>(

--- a/packages/core/tests/integration/elicitation-e2e.test.ts
+++ b/packages/core/tests/integration/elicitation-e2e.test.ts
@@ -214,12 +214,12 @@ describe("Elicitation E2E Tests", () => {
     });
 
     // Import the schema processing functions directly to test them
-    const { resolveToolSchema, toElicitationRequestedSchema } = await import(
+    const { resolveSchema, toElicitationRequestedSchema } = await import(
       "../../src/validation.js"
     );
 
     // Test schema resolution
-    const { mcpInputSchema } = resolveToolSchema(testSchema, (s) =>
+    const { mcpInputSchema } = resolveSchema(testSchema, (s) =>
       z.toJSONSchema(s as z.ZodType),
     );
 
@@ -261,7 +261,7 @@ describe("Elicitation E2E Tests", () => {
   });
 
   test("E2E: plain JSON Schema works correctly with elicitation", async () => {
-    const { resolveToolSchema, toElicitationRequestedSchema } = await import(
+    const { resolveSchema, toElicitationRequestedSchema } = await import(
       "../../src/validation.js"
     );
 
@@ -283,7 +283,7 @@ describe("Elicitation E2E Tests", () => {
     };
 
     // Test schema resolution with plain JSON Schema
-    const { mcpInputSchema } = resolveToolSchema(jsonSchema, undefined);
+    const { mcpInputSchema } = resolveSchema(jsonSchema, undefined);
 
     // Test elicitation schema projection
     const requestedSchema = toElicitationRequestedSchema(mcpInputSchema);

--- a/packages/core/tests/integration/elicitation-e2e.test.ts
+++ b/packages/core/tests/integration/elicitation-e2e.test.ts
@@ -219,12 +219,12 @@ describe("Elicitation E2E Tests", () => {
     );
 
     // Test schema resolution
-    const { mcpInputSchema } = resolveSchema(testSchema, (s) =>
+    const { resolvedSchema } = resolveSchema(testSchema, (s) =>
       z.toJSONSchema(s as z.ZodType),
     );
 
     // Test elicitation schema projection
-    const requestedSchema = toElicitationRequestedSchema(mcpInputSchema);
+    const requestedSchema = toElicitationRequestedSchema(resolvedSchema);
 
     // Verify the schema projection is correct
     expect(requestedSchema.type).toBe("object");
@@ -283,10 +283,10 @@ describe("Elicitation E2E Tests", () => {
     };
 
     // Test schema resolution with plain JSON Schema
-    const { mcpInputSchema } = resolveSchema(jsonSchema, undefined);
+    const { resolvedSchema } = resolveSchema(jsonSchema, undefined);
 
     // Test elicitation schema projection
-    const requestedSchema = toElicitationRequestedSchema(mcpInputSchema);
+    const requestedSchema = toElicitationRequestedSchema(resolvedSchema);
 
     // Verify schema is projected correctly from JSON Schema input
     expect(requestedSchema).toMatchObject({

--- a/packages/core/tests/integration/schema-projection.test.ts
+++ b/packages/core/tests/integration/schema-projection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { type } from "arktype";
 import { z } from "zod";
 import {
-  resolveToolSchema,
+  resolveSchema,
   toElicitationRequestedSchema,
 } from "../../src/validation.js";
 
@@ -358,11 +358,11 @@ describe("toElicitationRequestedSchema", () => {
       };
 
       expect(() => toElicitationRequestedSchema(standardSchema)).toThrow(
-        "Standard Schema inputs must be converted via resolveToolSchema first",
+        "Standard Schema inputs must be converted via resolveSchema first",
       );
     });
 
-    test("works with Zod schemas via resolveToolSchema", () => {
+    test("works with Zod schemas via resolveSchema", () => {
       const zodSchema = z.object({
         email: z.string().email().min(5).max(100),
         age: z.number().min(0).max(150),
@@ -375,7 +375,7 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => z.toJSONSchema(schema);
 
-      const { mcpInputSchema } = resolveToolSchema(zodSchema, schemaAdapter);
+      const { mcpInputSchema } = resolveSchema(zodSchema, schemaAdapter);
       const result = toElicitationRequestedSchema(mcpInputSchema);
 
       expect(result.type).toBe("object");
@@ -409,7 +409,7 @@ describe("toElicitationRequestedSchema", () => {
       expect(result.required).toEqual(["email", "age", "agree", "role"]);
     });
 
-    test("works with ArkType schemas via resolveToolSchema", () => {
+    test("works with ArkType schemas via resolveSchema", () => {
       const arkSchema = type({
         email: "string.email",
         age: "number>=0",
@@ -424,7 +424,7 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => schema.toJsonSchema();
 
-      const { mcpInputSchema } = resolveToolSchema(arkSchema, schemaAdapter);
+      const { mcpInputSchema } = resolveSchema(arkSchema, schemaAdapter);
       const result = toElicitationRequestedSchema(mcpInputSchema);
 
       // The exact structure depends on ArkType's JSON Schema output
@@ -469,7 +469,7 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => z.toJSONSchema(schema);
 
-      const { mcpInputSchema } = resolveToolSchema(
+      const { mcpInputSchema } = resolveSchema(
         complexSchema,
         schemaAdapter,
       );
@@ -522,8 +522,8 @@ describe("toElicitationRequestedSchema", () => {
     });
   });
 
-  describe("resolveToolSchema integration", () => {
-    test("works with resolved JSON Schema from resolveToolSchema", () => {
+  describe("resolveSchema integration", () => {
+    test("works with resolved JSON Schema from resolveSchema", () => {
       const jsonSchema = {
         type: "object",
         properties: {
@@ -533,7 +533,7 @@ describe("toElicitationRequestedSchema", () => {
         required: ["name"],
       };
 
-      const { mcpInputSchema } = resolveToolSchema(jsonSchema);
+      const { mcpInputSchema } = resolveSchema(jsonSchema);
       const result = toElicitationRequestedSchema(mcpInputSchema);
 
       expect(result).toEqual({
@@ -546,8 +546,8 @@ describe("toElicitationRequestedSchema", () => {
       });
     });
 
-    test("works with undefined schema via resolveToolSchema", () => {
-      const { mcpInputSchema } = resolveToolSchema();
+    test("works with undefined schema via resolveSchema", () => {
+      const { mcpInputSchema } = resolveSchema();
       const result = toElicitationRequestedSchema(mcpInputSchema);
 
       expect(result).toEqual({

--- a/packages/core/tests/integration/schema-projection.test.ts
+++ b/packages/core/tests/integration/schema-projection.test.ts
@@ -375,8 +375,8 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => z.toJSONSchema(schema);
 
-      const { mcpInputSchema } = resolveSchema(zodSchema, schemaAdapter);
-      const result = toElicitationRequestedSchema(mcpInputSchema);
+      const { resolvedSchema } = resolveSchema(zodSchema, schemaAdapter);
+      const result = toElicitationRequestedSchema(resolvedSchema);
 
       expect(result.type).toBe("object");
       expect(result.properties).toBeDefined();
@@ -424,8 +424,8 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => schema.toJsonSchema();
 
-      const { mcpInputSchema } = resolveSchema(arkSchema, schemaAdapter);
-      const result = toElicitationRequestedSchema(mcpInputSchema);
+      const { resolvedSchema } = resolveSchema(arkSchema, schemaAdapter);
+      const result = toElicitationRequestedSchema(resolvedSchema);
 
       // The exact structure depends on ArkType's JSON Schema output
       expect(result.type).toBe("object");
@@ -469,8 +469,8 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => z.toJSONSchema(schema);
 
-      const { mcpInputSchema } = resolveSchema(complexSchema, schemaAdapter);
-      const result = toElicitationRequestedSchema(mcpInputSchema);
+      const { resolvedSchema } = resolveSchema(complexSchema, schemaAdapter);
+      const result = toElicitationRequestedSchema(resolvedSchema);
 
       expect(result.type).toBe("object");
       expect(result.properties).toBeDefined();
@@ -530,8 +530,8 @@ describe("toElicitationRequestedSchema", () => {
         required: ["name"],
       };
 
-      const { mcpInputSchema } = resolveSchema(jsonSchema);
-      const result = toElicitationRequestedSchema(mcpInputSchema);
+      const { resolvedSchema } = resolveSchema(jsonSchema);
+      const result = toElicitationRequestedSchema(resolvedSchema);
 
       expect(result).toEqual({
         type: "object",
@@ -544,8 +544,8 @@ describe("toElicitationRequestedSchema", () => {
     });
 
     test("works with undefined schema via resolveSchema", () => {
-      const { mcpInputSchema } = resolveSchema();
-      const result = toElicitationRequestedSchema(mcpInputSchema);
+      const { resolvedSchema } = resolveSchema();
+      const result = toElicitationRequestedSchema(resolvedSchema);
 
       expect(result).toEqual({
         type: "object",

--- a/packages/core/tests/integration/schema-projection.test.ts
+++ b/packages/core/tests/integration/schema-projection.test.ts
@@ -469,10 +469,7 @@ describe("toElicitationRequestedSchema", () => {
       // biome-ignore lint/suspicious/noExplicitAny: tests
       const schemaAdapter = (schema: any) => z.toJSONSchema(schema);
 
-      const { mcpInputSchema } = resolveSchema(
-        complexSchema,
-        schemaAdapter,
-      );
+      const { mcpInputSchema } = resolveSchema(complexSchema, schemaAdapter);
       const result = toElicitationRequestedSchema(mcpInputSchema);
 
       expect(result.type).toBe("object");

--- a/packages/core/tests/integration/structured-content.test.ts
+++ b/packages/core/tests/integration/structured-content.test.ts
@@ -157,7 +157,11 @@ describe("Structured Content Support", () => {
     expect(result.error).toBeUndefined();
     expect(result.result).toBeDefined();
 
-    const tools = (result.result as { tools: Array<{ name: string; outputSchema?: unknown }> }).tools;
+    const tools = (
+      result.result as {
+        tools: Array<{ name: string; outputSchema?: unknown }>;
+      }
+    ).tools;
     const weatherTool = tools.find((t) => t.name === "getWeather");
     const dataTool = tools.find((t) => t.name === "getData");
     const echoTool = tools.find((t) => t.name === "echo");
@@ -317,6 +321,9 @@ describe("Structured Content Support", () => {
 
     expect(result.error).toBeUndefined();
     const toolResult = result.result as { structuredContent?: unknown };
-    expect(toolResult.structuredContent).toEqual({ anything: "goes", here: 123 });
+    expect(toolResult.structuredContent).toEqual({
+      anything: "goes",
+      here: 123,
+    });
   });
 });

--- a/packages/core/tests/integration/structured-content.test.ts
+++ b/packages/core/tests/integration/structured-content.test.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { type Type, type } from "arktype";
+import { McpServer, StreamableHttpTransport } from "../../src/index.js";
+import type { JsonRpcRes } from "../../src/types.js";
+
+describe("Structured Content Support", () => {
+  let handler: (request: Request) => Promise<Response>;
+
+  beforeEach(() => {
+    const mcp = new McpServer({
+      name: "structured-content-test",
+      version: "1.0.0",
+      schemaAdapter: (schema) => (schema as Type).toJsonSchema(),
+    });
+
+    // Tool with outputSchema (Standard Schema)
+    const weatherInput = type({ location: "string" });
+    const weatherOutput = type({
+      temperature: "number",
+      conditions: "string",
+      humidity: "number?",
+    });
+
+    mcp.tool("getWeather", {
+      description: "Gets weather with structured output",
+      inputSchema: weatherInput,
+      outputSchema: weatherOutput,
+      handler: (args: { location: string }) => ({
+        content: [
+          {
+            type: "text",
+            text: `Weather in ${args.location}: 22°C, sunny`,
+          },
+        ],
+        structuredContent: {
+          temperature: 22,
+          conditions: "sunny",
+          humidity: 65,
+        },
+      }),
+    });
+
+    // Tool with JSON Schema outputSchema
+    mcp.tool("getData", {
+      description: "Gets data with JSON Schema output",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+        },
+        required: ["id"],
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          value: { type: "number" },
+        },
+        required: ["id", "value"],
+      },
+      handler: (args: { id: string }) => ({
+        content: [{ type: "text", text: `Data for ${args.id}` }],
+        structuredContent: {
+          id: args.id,
+          value: 42,
+        },
+      }),
+    });
+
+    // Tool without outputSchema
+    mcp.tool("echo", {
+      description: "Echoes input without structured output",
+      inputSchema: { type: "object", properties: { text: { type: "string" } } },
+      handler: (args: { text: string }) => ({
+        content: [{ type: "text", text: args.text }],
+      }),
+    });
+
+    // Tool with outputSchema that returns invalid data
+    const strictOutput = type({
+      result: "string",
+      count: "number",
+    });
+
+    mcp.tool("invalidOutput", {
+      description: "Returns invalid structured content",
+      inputSchema: type({ input: "string" }),
+      outputSchema: strictOutput,
+      handler: () => ({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {
+          result: "text",
+          count: "not a number" as unknown as number, // Invalid!
+        },
+      }),
+    });
+
+    // Tool with outputSchema that returns error
+    mcp.tool("errorTool", {
+      description: "Returns error (skips validation)",
+      inputSchema: type({ input: "string" }),
+      outputSchema: weatherOutput,
+      handler: () => ({
+        content: [{ type: "text", text: "Error occurred" }],
+        isError: true,
+        // No structuredContent - should not throw error when isError=true
+      }),
+    });
+
+    const transport = new StreamableHttpTransport();
+    handler = transport.bind(mcp);
+  });
+
+  async function callTool(toolName: string, args: unknown) {
+    const request = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "tools/call",
+        params: {
+          name: toolName,
+          arguments: args,
+        },
+      }),
+    });
+
+    const response = await handler(request);
+    return (await response.json()) as JsonRpcRes;
+  }
+
+  async function listTools() {
+    const request = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "tools/list",
+      }),
+    });
+
+    const response = await handler(request);
+    return (await response.json()) as JsonRpcRes;
+  }
+
+  it("should include outputSchema in tools/list", async () => {
+    const result = await listTools();
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+
+    const tools = (result.result as { tools: Array<{ name: string; outputSchema?: unknown }> }).tools;
+    const weatherTool = tools.find((t) => t.name === "getWeather");
+    const dataTool = tools.find((t) => t.name === "getData");
+    const echoTool = tools.find((t) => t.name === "echo");
+
+    // Tool with outputSchema should expose it
+    expect(weatherTool?.outputSchema).toBeDefined();
+    const weatherSchema = weatherTool?.outputSchema as {
+      type: string;
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(weatherSchema.type).toBe("object");
+    expect(weatherSchema.properties.temperature).toEqual({ type: "number" });
+    expect(weatherSchema.properties.conditions).toEqual({ type: "string" });
+    expect(weatherSchema.properties.humidity).toEqual({ type: "number" });
+    expect(weatherSchema.required).toContain("temperature");
+    expect(weatherSchema.required).toContain("conditions");
+
+    // JSON Schema output should be exposed
+    expect(dataTool?.outputSchema).toBeDefined();
+    expect(dataTool?.outputSchema).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        value: { type: "number" },
+      },
+      required: ["id", "value"],
+    });
+
+    // Tool without outputSchema should not have it
+    expect(echoTool?.outputSchema).toBeUndefined();
+  });
+
+  it("should return valid structuredContent with Standard Schema", async () => {
+    const result = await callTool("getWeather", { location: "Paris" });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+
+    const toolResult = result.result as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent?: {
+        temperature: number;
+        conditions: string;
+        humidity?: number;
+      };
+    };
+
+    expect(toolResult.content).toHaveLength(1);
+    expect(toolResult.content[0].text).toContain("Paris");
+
+    expect(toolResult.structuredContent).toBeDefined();
+    expect(toolResult.structuredContent?.temperature).toBe(22);
+    expect(toolResult.structuredContent?.conditions).toBe("sunny");
+    expect(toolResult.structuredContent?.humidity).toBe(65);
+  });
+
+  it("should return valid structuredContent with JSON Schema", async () => {
+    const result = await callTool("getData", { id: "test-123" });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+
+    const toolResult = result.result as {
+      content: unknown[];
+      structuredContent?: {
+        id: string;
+        value: number;
+      };
+    };
+
+    expect(toolResult.structuredContent).toBeDefined();
+    expect(toolResult.structuredContent?.id).toBe("test-123");
+    expect(toolResult.structuredContent?.value).toBe(42);
+  });
+
+  it("should not require structuredContent when no outputSchema", async () => {
+    const result = await callTool("echo", { text: "hello" });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+
+    const toolResult = result.result as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent?: unknown;
+    };
+
+    expect(toolResult.content).toHaveLength(1);
+    expect(toolResult.content[0].text).toBe("hello");
+    // structuredContent is optional when no outputSchema
+    expect(toolResult.structuredContent).toBeUndefined();
+  });
+
+  it("should throw error for invalid structuredContent", async () => {
+    const result = await callTool("invalidOutput", { input: "test" });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe(-32602); // INVALID_PARAMS
+    expect(result.error?.message).toContain("invalid structured content");
+  });
+
+  it("should skip validation when isError is true", async () => {
+    const result = await callTool("errorTool", { input: "test" });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBeDefined();
+
+    const toolResult = result.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: unknown;
+    };
+
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content[0].text).toBe("Error occurred");
+    // No error thrown even though structuredContent is missing
+  });
+
+  it("should allow structuredContent without outputSchema (unvalidated)", async () => {
+    // Register a tool that returns structuredContent but has no outputSchema
+    const mcp = new McpServer({
+      name: "test",
+      version: "1.0.0",
+    });
+
+    mcp.tool("unvalidated", {
+      handler: () => ({
+        content: [{ type: "text", text: "data" }],
+        structuredContent: { anything: "goes", here: 123 },
+      }),
+    });
+
+    const transport = new StreamableHttpTransport();
+    const testHandler = transport.bind(mcp);
+
+    const result = await (async () => {
+      const request = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "1",
+          method: "tools/call",
+          params: {
+            name: "unvalidated",
+            arguments: {},
+          },
+        }),
+      });
+
+      const response = await testHandler(request);
+      return (await response.json()) as JsonRpcRes;
+    })();
+
+    expect(result.error).toBeUndefined();
+    const toolResult = result.result as { structuredContent?: unknown };
+    expect(toolResult.structuredContent).toEqual({ anything: "goes", here: 123 });
+  });
+});


### PR DESCRIPTION
Addresses #38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `structuredContent` support to tools with optional `outputSchema`, runtime validation, and updated schema resolution API.
> 
> - **Core API**:
>   - Tools now accept optional `outputSchema` (Standard or JSON Schema) and may return `structuredContent` in `ToolCallResult`.
>   - Added multiple `tool()` overloads for typed input/output; tools/list now includes `outputSchema`.
>   - Validate `structuredContent` at call time when `outputSchema` is present; propagate validator through `group()`.
> - **Schema/Validation**:
>   - Renamed `resolveToolSchema` → `resolveSchema`; updated error strings and call sites.
>   - Exposed `createValidationFunction` for output validation.
> - **Types**:
>   - `Tool` includes `outputSchema`; `ToolEntry` includes `outputValidator`.
>   - `ToolCallResult` is generic and adds optional `structuredContent`.
> - **Elicitation**:
>   - Updated to use `resolveSchema` and adjusted projection helper.
> - **Tests/Examples**:
>   - Added integration tests for structured outputs, grouping preservation, and schema projection; updated existing tests to `resolveSchema`.
>   - Playground `getWeather` example demonstrates structured output.
> - **Release**: Minor version bump (`mcp-lite: minor`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb1210522aa2b3cac4eda6c851aac9cb06dc0147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->