### PR TITLE
Update templates to use mcp-lite 0.8.2

### DIFF
--- a/templates/starter-chatgpt-app-sdk/package.json
+++ b/templates/starter-chatgpt-app-sdk/package.json
@@ -12,7 +12,7 @@
     "@hono/node-server": "^1.19.5",
     "@tanstack/react-router": "^1.132.47",
     "hono": "^4.9.12",
-    "mcp-lite": "^0.8.1",
+    "mcp-lite": "^0.8.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.14",

--- a/templates/starter-mcp-bun/package.json
+++ b/templates/starter-mcp-bun/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "hono": "^4.9.6",
-    "mcp-lite": "^0.8.1",
+    "mcp-lite": "^0.8.2",
     "zod": "^4.1.5"
   },
   "devDependencies": {

--- a/templates/starter-mcp-cloudflare/package.json
+++ b/templates/starter-mcp-cloudflare/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "hono": "^4.9.12",
-    "mcp-lite": "^0.8.1"
+    "mcp-lite": "^0.8.2"
   },
   "devDependencies": {
     "wrangler": "^4.42.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade mcp-lite to ^0.8.2 across all starter templates.
> 
> - **Dependencies**:
>   - Bump `mcp-lite` to `^0.8.2` in:
>     - `templates/starter-chatgpt-app-sdk/package.json`
>     - `templates/starter-mcp-bun/package.json`
>     - `templates/starter-mcp-cloudflare/package.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b169f21a2e61b08bacdca67e9733ccb8a4f988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->