### PR TITLE
Update supabase template starter README

### DIFF
--- a/templates/starter-mcp-supabase/README.md
+++ b/templates/starter-mcp-supabase/README.md
@@ -9,14 +9,11 @@ Minimal MCP server built with mcp-lite and deployed as a Supabase Edge Function 
 
 ## Getting Started
 
-1. **Initialize Supabase project** (if not already done):
+1. **Start local development**:
 ```bash
-supabase init
-```
-
-2. **Start local development**:
-```bash
+# Start Supabase services
 supabase start
+# Serve your MCP function locally
 supabase functions serve --no-verify-jwt mcp-server
 ```
 
@@ -24,7 +21,7 @@ The MCP server will be available at:
 - Main endpoint: `http://localhost:54321/functions/v1/mcp-server/mcp`
 - Health check: `http://localhost:54321/functions/v1/mcp-server/health`
 
-3. **Deploy to Supabase**:
+2. **Deploy to Supabase**:
 ```bash
 supabase functions deploy --no-verify-jwt mcp-server
 ```

--- a/templates/starter-mcp-supabase/package.json
+++ b/templates/starter-mcp-supabase/package.json
@@ -7,9 +7,9 @@
   },
   "dependencies": {
     "hono": "^4.9.12",
-    "mcp-lite": "^0.8.1"
+    "mcp-lite": "^0.9.0"
   },
   "devDependencies": {
-    "supabase": "^2.53.6"
+    "supabase": "^2.54.11"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines Supabase MCP starter README setup and bumps `mcp-lite` and `supabase` versions.
> 
> - **Docs (`templates/starter-mcp-supabase/README.md`)**
>   - Streamlines Getting Started by removing project init step, clarifying local serve commands, and renumbering steps.
>   - Highlights local endpoints and deploy command usage.
> - **Dependencies (`templates/starter-mcp-supabase/package.json`)**
>   - Bump `mcp-lite` to `^0.9.0`.
>   - Bump `supabase` dev dependency to `^2.54.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cdaccdae5fe7cb2642a87f8edb0da8920f9dd5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->