### PR TITLE
`starter-cloudflare`: update wrangler to 4.45.0 

### DIFF
--- a/templates/starter-mcp-cloudflare/package.json
+++ b/templates/starter-mcp-cloudflare/package.json
@@ -8,10 +8,9 @@
   },
   "dependencies": {
     "hono": "^4.9.12",
-    "mcp-lite": "^0.8.2",
-    "zod": "^4.1.5"
+    "mcp-lite": "^0.8.2"
   },
   "devDependencies": {
-    "wrangler": "^4.42.2"
+    "wrangler": "^4.45.0"
   }
 }

--- a/templates/starter-mcp-cloudflare/wrangler.jsonc
+++ b/templates/starter-mcp-cloudflare/wrangler.jsonc
@@ -12,7 +12,6 @@
   // "kv_namespaces": [
   //   {
   //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   //   }
   // ],
   // "r2_buckets": [
@@ -23,9 +22,7 @@
   // ],
   // "d1_databases": [
   //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
+  //     "binding": "MY_DB"
   //   }
   // ],
   // "ai": {


### PR DESCRIPTION
## Changes
- Updated wrangler dependency from ^3.96.0 to ^4.45.0 in `templates/starter-mcp-cloudflare/package.json`
- Updated binding examples in `wrangler.jsonc` to leverage automatic resource provisioning for D1, KV, and R2

## Key Feature: Automatic Resource Provisioning
With wrangler 4.45.0, you can now add bindings without resource IDs:
wrangler dev creates resources locally, and wrangler deploy creates and links them automatically. 

Read more: https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.45.0