### PR TITLE
feat: Add uiResource API with React hooks for interactive widgets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,34 @@
         "typescript": "^5.7.2",
       },
     },
+    "examples/react-widget": {
+      "name": "@mcp-lite/example-react-widget",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.6.14",
+        "mcp-lite": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.2",
+      },
+    },
+    "examples/react-widget/widget-app": {
+      "name": "weather-widget-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mcp-lite/react": "workspace:*",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.7",
+      },
+    },
     "examples/sampling": {
       "name": "@mcp-lite-examples/sampling",
       "version": "1.0.3",
@@ -148,7 +176,7 @@
     },
     "packages/core": {
       "name": "mcp-lite",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
       },
@@ -161,7 +189,7 @@
     },
     "packages/create-mcp-lite": {
       "name": "create-mcp-lite",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "create-mcp-lite": "dist/index.js",
       },
@@ -177,6 +205,18 @@
       "devDependencies": {
         "@types/node": "^22.2.0",
         "typescript": "^5.9.2",
+      },
+    },
+    "packages/react": {
+      "name": "@mcp-lite/react",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^18.3.18",
+        "react": "^18.3.1",
+        "typescript": "^5.7.2",
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
       },
     },
     "packages/test-utils": {
@@ -217,7 +257,45 @@
 
     "@ark/util": ["@ark/util@0.49.0", "", {}, "sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.28.5", "", {}, "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA=="],
+
+    "@babel/core": ["@babel/core@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw=="],
+
+    "@babel/generator": ["@babel/generator@7.28.5", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.27.2", "", { "dependencies": { "@babel/compat-data": "^7.27.2", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.3", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1", "@babel/traverse": "^7.28.3" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.27.1", "", {}, "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
+
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+
+    "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
+
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.2.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.5", "@biomejs/cli-darwin-x64": "2.2.5", "@biomejs/cli-linux-arm64": "2.2.5", "@biomejs/cli-linux-arm64-musl": "2.2.5", "@biomejs/cli-linux-x64": "2.2.5", "@biomejs/cli-linux-x64-musl": "2.2.5", "@biomejs/cli-win32-arm64": "2.2.5", "@biomejs/cli-win32-x64": "2.2.5" }, "bin": { "biome": "bin/biome" } }, "sha512-zcIi+163Rc3HtyHbEO7CjeHq8DjQRs40HsGbW6vx2WI0tg8mYQOPouhvHSyEnCBAorfYNnKdR64/IxO7xQ5faw=="],
 
@@ -409,6 +487,10 @@
 
     "@internal/test-utils": ["@internal/test-utils@workspace:packages/test-utils"],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -440,6 +522,10 @@
     "@mcp-lite-examples/validation-valibot": ["@mcp-lite-examples/validation-valibot@workspace:examples/validation-valibot"],
 
     "@mcp-lite-examples/validation-zod": ["@mcp-lite-examples/validation-zod@workspace:examples/validation-zod"],
+
+    "@mcp-lite/example-react-widget": ["@mcp-lite/example-react-widget@workspace:examples/react-widget"],
+
+    "@mcp-lite/react": ["@mcp-lite/react@workspace:packages/react"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.19.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ=="],
 
@@ -479,6 +565,52 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.2", "", {}, "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg=="],
 
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.5", "", { "os": "android", "cpu": "arm" }, "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.52.5", "", { "os": "android", "cpu": "arm64" }, "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.52.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.52.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.52.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.52.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.52.5", "", { "os": "linux", "cpu": "arm" }, "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.52.5", "", { "os": "linux", "cpu": "arm" }, "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.52.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.52.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.52.5", "", { "os": "linux", "cpu": "none" }, "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.52.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.52.5", "", { "os": "linux", "cpu": "none" }, "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.52.5", "", { "os": "linux", "cpu": "none" }, "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.52.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.52.5", "", { "os": "linux", "cpu": "x64" }, "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.52.5", "", { "os": "linux", "cpu": "x64" }, "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.52.5", "", { "os": "none", "cpu": "arm64" }, "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.52.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.52.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@7.1.0", "", {}, "sha512-7F/yz2IphV39hiS2zB4QYVkivrptHHh0K8qJJd9HhuWSdvf8AN7NpebW3CcDZDBQsUPMoDKWsY2WWgW7bqOcfA=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.7", "", {}, "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="],
@@ -487,13 +619,29 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/bun": ["@types/bun@1.3.0", "", { "dependencies": { "bun-types": "1.3.0" } }, "sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@22.18.8", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw=="],
 
-    "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.26", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA=="],
+
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.3.0", "", { "peerDependencies": { "valibot": "^1.1.0" } }, "sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
@@ -521,6 +669,8 @@
 
     "avvio": ["avvio@9.1.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.23", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ=="],
+
     "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
@@ -530,6 +680,8 @@
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.27.0", "", { "dependencies": { "baseline-browser-mapping": "^2.8.19", "caniuse-lite": "^1.0.30001751", "electron-to-chromium": "^1.5.238", "node-releases": "^2.0.26", "update-browserslist-db": "^1.1.4" }, "bin": { "browserslist": "cli.js" } }, "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw=="],
 
     "bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
 
@@ -542,6 +694,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001753", "", {}, "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw=="],
 
     "chardet": ["chardet@2.1.0", "", {}, "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA=="],
 
@@ -570,6 +724,8 @@
     "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
@@ -615,6 +771,8 @@
 
     "effect": ["effect@3.18.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.244", "", {}, "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
@@ -630,6 +788,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -701,6 +861,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -767,11 +929,17 @@
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -782,6 +950,10 @@
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -817,11 +989,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "nypm": ["nypm@0.5.4", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "tinyexec": "^0.3.2", "ufo": "^1.5.4" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA=="],
 
@@ -887,6 +1063,8 @@
 
     "playground": ["playground@workspace:playground"],
 
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
@@ -917,7 +1095,11 @@
 
     "raw-body": ["raw-body@3.0.1", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.7.0", "unpipe": "1.0.0" } }, "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA=="],
 
-    "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
@@ -935,6 +1117,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "rollup": ["rollup@4.52.5", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.5", "@rollup/rollup-android-arm64": "4.52.5", "@rollup/rollup-darwin-arm64": "4.52.5", "@rollup/rollup-darwin-x64": "4.52.5", "@rollup/rollup-freebsd-arm64": "4.52.5", "@rollup/rollup-freebsd-x64": "4.52.5", "@rollup/rollup-linux-arm-gnueabihf": "4.52.5", "@rollup/rollup-linux-arm-musleabihf": "4.52.5", "@rollup/rollup-linux-arm64-gnu": "4.52.5", "@rollup/rollup-linux-arm64-musl": "4.52.5", "@rollup/rollup-linux-loong64-gnu": "4.52.5", "@rollup/rollup-linux-ppc64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-musl": "4.52.5", "@rollup/rollup-linux-s390x-gnu": "4.52.5", "@rollup/rollup-linux-x64-gnu": "4.52.5", "@rollup/rollup-linux-x64-musl": "4.52.5", "@rollup/rollup-openharmony-arm64": "4.52.5", "@rollup/rollup-win32-arm64-msvc": "4.52.5", "@rollup/rollup-win32-ia32-msvc": "4.52.5", "@rollup/rollup-win32-x64-gnu": "4.52.5", "@rollup/rollup-win32-x64-msvc": "4.52.5", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -948,6 +1132,8 @@
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
@@ -986,6 +1172,8 @@
     "slow-redact": ["slow-redact@0.3.1", "", {}, "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ=="],
 
     "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
@@ -1059,6 +1247,8 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
@@ -1070,6 +1260,10 @@
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "weather-widget-app": ["weather-widget-app@workspace:examples/react-widget/widget-app"],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -1101,9 +1295,19 @@
 
     "@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@clack/prompts/is-unicode-supported": ["is-unicode-supported@2.1.0", "", { "bundled": true }, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "@fastify/ajv-compiler/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -1114,6 +1318,8 @@
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@mcp-lite-examples/text-to-speech/@types/node": ["@types/node@20.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg=="],
+
+    "@mcp-lite/example-react-widget/@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -1133,6 +1339,8 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "bun-types/@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-json-stringify/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
@@ -1142,6 +1350,8 @@
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1167,6 +1377,8 @@
 
     "@fastify/ajv-compiler/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@mcp-lite/example-react-widget/@types/bun/bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
+
     "@octokit/auth-action/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
@@ -1184,5 +1396,9 @@
     "fast-json-stringify/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "playground/@types/bun/bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
+
+    "@mcp-lite/example-react-widget/@types/bun/bun-types/@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
+
+    "playground/@types/bun/bun-types/@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
   }
 }

--- a/examples/react-widget/README.md
+++ b/examples/react-widget/README.md
@@ -1,0 +1,214 @@
+# React Widget Example
+
+This example demonstrates how to integrate React widgets with mcp-lite's `uiResource()` system.
+
+## What's Included
+
+This example shows three different widget patterns:
+
+1. **Inline Counter** (`rawHtml`) - A vanilla JS widget that mimics React's `useWidget` hook pattern
+2. **Weather Widget** (`externalUrl`) - How to register an externally hosted React app
+3. **Task List** (`remoteDom`) - A lightweight interactive widget using DOM scripting
+
+## Quick Start
+
+```bash
+# Terminal 1: Start the React widget dev server
+cd examples/react-widget/widget-app
+bun install
+bun run dev  # Runs on http://localhost:5173
+
+# Terminal 2: Start the MCP server
+cd examples/react-widget
+bun install
+bun run dev  # Runs on http://localhost:3002
+
+# Terminal 3: Run manual tests
+cd examples/react-widget
+bun run test:manual
+```
+
+📖 **See [TESTING.md](./TESTING.md) for complete manual testing guide**
+
+## Key Concepts
+
+### How Props Flow to React Widgets
+
+1. **Tool Call**: LLM calls your widget tool with args (e.g., `{ city: "Paris", temperature: 22 }`)
+2. **Server**: mcp-lite returns a `resource_link` with props encoded in the URL
+3. **HTML Injection**: The server injects `window.openai.toolInput = { city: "Paris", ... }`
+4. **React Hook**: Your React component uses `useWidget()` to read from `window.openai.toolInput`
+5. **Render**: Component receives typed props and renders
+
+### Widget Registration
+
+```ts
+server.uiResource({
+  type: "externalUrl",
+  name: "my-widget",
+  url: "https://my-app.vercel.app/widget",  // Your deployed React app
+  inputSchema: {
+    type: "object",
+    properties: {
+      city: { type: "string" },
+      temperature: { type: "number" }
+    }
+  }
+});
+```
+
+## Building a Real React Widget
+
+### 1. Create React App
+
+```bash
+# Create a new React + Vite project
+npm create vite@latest my-widget -- --template react-ts
+cd my-widget
+npm install @mcp-lite/react
+```
+
+### 2. Create Widget Component
+
+```tsx
+// src/WeatherWidget.tsx
+import { useWidget } from "@mcp-lite/react";
+
+interface WeatherProps {
+  city: string;
+  temperature: number;
+  weather: "sunny" | "rain" | "snow" | "cloudy";
+}
+
+export default function WeatherWidget() {
+  const { props, theme, callTool, sendFollowUpMessage } = useWidget<WeatherProps>();
+
+  const handleForecast = async () => {
+    const result = await callTool("get-forecast", { city: props.city });
+    console.log(result);
+  };
+
+  return (
+    <div data-theme={theme} className="p-6">
+      <h1 className="text-2xl font-bold">{props.city}</h1>
+      <p className="text-4xl my-4">{props.temperature}°C</p>
+      <p className="capitalize">{props.weather}</p>
+      
+      <button 
+        onClick={handleForecast}
+        className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        Get Forecast
+      </button>
+    </div>
+  );
+}
+```
+
+### 3. Build and Deploy
+
+```bash
+# Build for production
+npm run build
+
+# Deploy to Vercel/Netlify/Cloudflare Pages
+vercel deploy
+```
+
+### 4. Register with MCP Server
+
+```ts
+import { McpServer } from "mcp-lite";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+
+server.uiResource({
+  type: "externalUrl",
+  name: "weather-widget",
+  url: "https://your-app.vercel.app",  // Your deployed URL
+  inputSchema: {
+    type: "object",
+    properties: {
+      city: { type: "string" },
+      temperature: { type: "number" },
+      weather: { type: "string", enum: ["sunny", "rain", "snow", "cloudy"] }
+    },
+    required: ["city", "temperature", "weather"]
+  }
+});
+```
+
+## Running This Example
+
+```bash
+# From the example directory
+bun install
+bun run dev
+
+# Or from repo root
+bun run --filter=@mcp-lite/example-react-widget dev
+```
+
+Visit `http://localhost:3002/health` to verify the server is running.
+
+## Testing Widgets
+
+### With MCP Inspector
+
+1. Start the server: `bun run dev`
+2. Use an MCP inspector tool to connect to `http://localhost:3002/mcp`
+3. Call tools like `inline-counter` with args: `{ "initialCount": 5 }`
+4. View the rendered widget
+
+### With ChatGPT
+
+1. Deploy your server to a public URL
+2. Register your MCP server with ChatGPT
+3. Ask: "Show me a counter starting at 10"
+4. ChatGPT will invoke the widget tool and display the UI
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│ MCP Client (ChatGPT)                                │
+│   Calls tool: weather-widget({ city: "Paris", ... })│
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│ mcp-lite Server                                     │
+│   server.uiResource({ type: "externalUrl", ... })   │
+│   Returns: resource_link to HTML                    │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│ HTML Wrapper (generated by mcp-lite)                │
+│   <script>                                          │
+│     window.openai.toolInput = { city: "Paris", ... }│
+│   </script>                                         │
+│   <iframe src="https://your-app.vercel.app" />     │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│ React App (your widget)                             │
+│   const { props } = useWidget<WeatherProps>();      │
+│   // props.city === "Paris" ✅                       │
+└─────────────────────────────────────────────────────┘
+```
+
+## Tips
+
+- **Type Safety**: Use TypeScript + Zod schemas for full type inference
+- **Themes**: Always support both `light` and `dark` themes
+- **Fallbacks**: Provide sensible defaults for all props
+- **State**: Use `useWidgetState()` for persistent state across interactions
+- **Testing**: Test standalone before integrating with MCP
+
+## Next Steps
+
+- See [@mcp-lite/react](../../packages/react) for full API docs
+- Check out other examples in [examples/](../)
+- Read the [uiResource() guide](../../packages/core#ui-widgets-experimental) in the core README

--- a/examples/react-widget/TESTING.md
+++ b/examples/react-widget/TESTING.md
@@ -1,0 +1,534 @@
+# Manual Testing Guide for React Widgets
+
+This guide shows you how to manually test React widgets with mcp-lite in different scenarios.
+
+## Testing Scenarios
+
+1. **Standalone Testing** - Test React widget in isolation (browser only)
+2. **Server Integration Testing** - Test widget served by MCP server
+3. **End-to-End Testing** - Test with MCP Inspector or Claude Desktop
+
+---
+
+## 1. Standalone Testing (React Widget Only)
+
+Test your React widget in isolation before integrating with the MCP server.
+
+### Setup
+
+```bash
+cd examples/react-widget/widget-app
+bun install
+bun run dev
+```
+
+This starts Vite dev server at `http://localhost:5173`
+
+### Test Cases
+
+#### A. Test with Default Props
+
+Open `http://localhost:5173` - Should show weather widget with defaults:
+- City: "Unknown"
+- Temperature: 0
+- Weather: "cloudy"
+
+#### B. Test with Simulated Props
+
+Open browser console and manually inject `window.openai`:
+
+```javascript
+// Simulate OpenAI Apps SDK environment
+window.openai = {
+  toolInput: {
+    city: "Paris",
+    temperature: 22,
+    weather: "sunny"
+  },
+  theme: "dark"
+};
+
+// Reload the page to pick up new props
+location.reload();
+```
+
+**Expected**: Widget shows Paris, 22°, sunny with dark theme
+
+#### C. Test Theme Switching
+
+```javascript
+window.openai = {
+  toolInput: { city: "London", temperature: 15, weather: "rain" },
+  theme: "light"  // Try "light" and "dark"
+};
+location.reload();
+```
+
+**Expected**: Widget adapts background/text colors based on theme
+
+#### D. Test Missing window.openai
+
+Clear `window.openai` and reload:
+
+```javascript
+delete window.openai;
+location.reload();
+```
+
+**Expected**: 
+- Widget shows "Standalone Mode" notice
+- Action buttons show alert when clicked
+- Default props are used
+
+---
+
+## 2. Server Integration Testing
+
+Test the widget served through the MCP server's `uiResource()`.
+
+### Setup
+
+Terminal 1 - Start Widget Dev Server:
+```bash
+cd examples/react-widget/widget-app
+bun run dev
+# Running at http://localhost:5173
+```
+
+Terminal 2 - Start MCP Server:
+```bash
+cd examples/react-widget
+bun run dev
+# Running at http://localhost:3002
+```
+
+### Test Cases
+
+#### A. List Available Tools
+
+```bash
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {},
+      "clientInfo": { "name": "test", "version": "1.0" }
+    }
+  }'
+```
+
+Save the `MCP-Session-Id` from response headers.
+
+```bash
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "MCP-Session-Id: <session-id>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/list"
+  }'
+```
+
+**Expected**: Response includes:
+- `inline-counter`
+- `weather-widget`
+- `task-list`
+
+#### B. Call a Widget Tool
+
+```bash
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "MCP-Session-Id: <session-id>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tools/call",
+    "params": {
+      "name": "inline-counter",
+      "arguments": {
+        "initialCount": 10
+      }
+    }
+  }'
+```
+
+**Expected**: Response contains:
+- `content[0].type === "resource_link"`
+- `content[0].uri` starts with `ui://widget/inline-counter-`
+- `structuredContent.initialCount === 10`
+
+#### C. Read Widget Resource
+
+Extract the `uri` from previous response, then:
+
+```bash
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "MCP-Session-Id: <session-id>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "4",
+    "method": "resources/read",
+    "params": {
+      "uri": "ui://widget/inline-counter-abc123.html?props=%7B%22initialCount%22%3A10%7D"
+    }
+  }'
+```
+
+**Expected**: Response contains HTML with:
+- `window.openai.toolInput` script tag
+- Props decoded: `{ initialCount: 10 }`
+
+#### D. Test External URL Widget
+
+```bash
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "MCP-Session-Id: <session-id>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "5",
+    "method": "tools/call",
+    "params": {
+      "name": "weather-widget",
+      "arguments": {
+        "city": "Tokyo",
+        "temperature": 25,
+        "weather": "sunny"
+      }
+    }
+  }'
+```
+
+Then read the resource and verify it contains an iframe pointing to the external URL.
+
+---
+
+## 3. End-to-End Testing with Browser
+
+### Setup
+
+1. Start both servers (widget-app on :5173, MCP server on :3002)
+2. Create a simple HTML test page
+
+### Test Page
+
+Create `examples/react-widget/test.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Widget Test Page</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    .test-section { margin: 20px 0; padding: 20px; border: 1px solid #ddd; }
+    iframe { width: 100%; height: 500px; border: 1px solid #ccc; }
+    button { padding: 10px 20px; margin: 5px; }
+  </style>
+</head>
+<body>
+  <h1>mcp-lite Widget Testing</h1>
+  
+  <div class="test-section">
+    <h2>Test 1: Inline Counter (rawHtml)</h2>
+    <button onclick="loadCounter(0)">Load with 0</button>
+    <button onclick="loadCounter(10)">Load with 10</button>
+    <button onclick="loadCounter(100)">Load with 100</button>
+    <div id="counter-container"></div>
+  </div>
+
+  <div class="test-section">
+    <h2>Test 2: Weather Widget (externalUrl)</h2>
+    <button onclick="loadWeather('Paris', 22, 'sunny')">Paris Sunny</button>
+    <button onclick="loadWeather('London', 15, 'rain')">London Rainy</button>
+    <button onclick="loadWeather('Tokyo', 28, 'cloudy')">Tokyo Cloudy</button>
+    <div id="weather-container"></div>
+  </div>
+
+  <div class="test-section">
+    <h2>Test 3: Task List (remoteDom)</h2>
+    <button onclick="loadTasks(['Buy groceries', 'Walk dog'])">2 Tasks</button>
+    <button onclick="loadTasks([])">Empty List</button>
+    <button onclick="loadTasks(['Task 1', 'Task 2', 'Task 3', 'Task 4'])">4 Tasks</button>
+    <div id="tasks-container"></div>
+  </div>
+
+  <script>
+    const MCP_URL = 'http://localhost:3002/mcp';
+    let sessionId = null;
+
+    async function initSession() {
+      if (sessionId) return sessionId;
+      
+      const res = await fetch(MCP_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'MCP-Protocol-Version': '2025-06-18'
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: '1',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0' }
+          }
+        })
+      });
+      
+      sessionId = res.headers.get('MCP-Session-Id');
+      return sessionId;
+    }
+
+    async function callTool(name, args) {
+      await initSession();
+      
+      const res = await fetch(MCP_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'MCP-Protocol-Version': '2025-06-18',
+          'MCP-Session-Id': sessionId
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: Math.random().toString(),
+          method: 'tools/call',
+          params: { name, arguments: args }
+        })
+      });
+      
+      return res.json();
+    }
+
+    async function readResource(uri) {
+      await initSession();
+      
+      const res = await fetch(MCP_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'MCP-Protocol-Version': '2025-06-18',
+          'MCP-Session-Id': sessionId
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: Math.random().toString(),
+          method: 'resources/read',
+          params: { uri }
+        })
+      });
+      
+      return res.json();
+    }
+
+    async function loadCounter(initialCount) {
+      const result = await callTool('inline-counter', { initialCount });
+      const uri = result.result.content[0].uri;
+      const resource = await readResource(uri);
+      const html = resource.result.contents[0].text;
+      
+      const container = document.getElementById('counter-container');
+      container.innerHTML = '';
+      const iframe = document.createElement('iframe');
+      iframe.srcdoc = html;
+      container.appendChild(iframe);
+    }
+
+    async function loadWeather(city, temperature, weather) {
+      const result = await callTool('weather-widget', { city, temperature, weather });
+      const uri = result.result.content[0].uri;
+      const resource = await readResource(uri);
+      const html = resource.result.contents[0].text;
+      
+      const container = document.getElementById('weather-container');
+      container.innerHTML = '';
+      const iframe = document.createElement('iframe');
+      iframe.srcdoc = html;
+      container.appendChild(iframe);
+    }
+
+    async function loadTasks(tasks) {
+      const result = await callTool('task-list', { tasks });
+      const uri = result.result.content[0].uri;
+      const resource = await readResource(uri);
+      const html = resource.result.contents[0].text;
+      
+      const container = document.getElementById('tasks-container');
+      container.innerHTML = '';
+      const iframe = document.createElement('iframe');
+      iframe.srcdoc = html;
+      container.appendChild(iframe);
+    }
+  </script>
+</body>
+</html>
+```
+
+### Running the Test
+
+```bash
+cd examples/react-widget
+python3 -m http.server 8000
+# Or: python -m SimpleHTTPServer 8000
+# Or any static file server
+```
+
+Open `http://localhost:8000/test.html`
+
+**Test Actions:**
+1. Click "Load with 10" → Counter shows 10
+2. Click increment buttons → Counter updates
+3. Click "Paris Sunny" → Weather widget loads in iframe with props
+4. Click "2 Tasks" → Task list shows with checkboxes
+
+---
+
+## 4. Testing with MCP Inspector
+
+If you have the MCP Inspector tool:
+
+```bash
+# Start MCP server
+cd examples/react-widget
+bun run dev
+
+# In another terminal, start inspector
+npx @modelcontextprotocol/inspector http://localhost:3002/mcp
+```
+
+**Test Flow:**
+1. Connect to server
+2. Navigate to "Tools" tab
+3. Select `inline-counter` tool
+4. Fill arguments: `{ "initialCount": 50 }`
+5. Click "Call Tool"
+6. Copy resource URI from response
+7. Navigate to "Resources" tab
+8. Paste URI and click "Read"
+9. Verify HTML contains correct props
+
+---
+
+## 5. Debugging Tips
+
+### Check Props Injection
+
+In any widget iframe, open DevTools console:
+
+```javascript
+// Should show your props
+console.log(window.openai?.toolInput);
+
+// Should show theme
+console.log(window.openai?.theme);
+```
+
+### Verify Resource URI Encoding
+
+Props are URL-encoded in the resource URI. To decode:
+
+```javascript
+const uri = "ui://widget/counter-abc.html?props=%7B%22initialCount%22%3A10%7D";
+const url = new URL(uri);
+const propsParam = url.searchParams.get('props');
+const props = JSON.parse(decodeURIComponent(propsParam));
+console.log(props); // { initialCount: 10 }
+```
+
+### Test Theme Changes
+
+In widget DevTools console:
+
+```javascript
+// Simulate theme change
+window.openai = { ...window.openai, theme: 'dark' };
+location.reload();
+```
+
+### Network Tab
+
+Check MCP server responses:
+- `tools/call` should return `resource_link`
+- `resources/read` should return HTML with proper props script
+
+---
+
+## Common Issues
+
+### Issue: Widget shows "Standalone Mode"
+
+**Cause**: `window.openai` not available
+
+**Solutions**:
+- Check if props are injected in HTML (View Source)
+- Verify iframe srcdoc includes the script tag
+- Test prop encoding/decoding
+
+### Issue: Props are empty/undefined
+
+**Cause**: Props not passed correctly through the flow
+
+**Check**:
+1. Tool call includes correct arguments
+2. Resource URI has `?props=...` query param
+3. Server decodes props correctly
+4. HTML script injects into `window.openai.toolInput`
+
+### Issue: Theme not applying
+
+**Cause**: Theme value not passed or widget not reading it
+
+**Solutions**:
+- Check `window.openai.theme` in DevTools
+- Verify widget reads theme from `useWidget()` hook
+- Test with manual theme injection
+
+### Issue: External URL widget shows wrong URL
+
+**Cause**: URL not matching between dev and production
+
+**Solutions**:
+- Update `url` in `uiResource()` config
+- For dev: use `http://localhost:5173`
+- For prod: use deployed URL (Vercel/Netlify)
+
+---
+
+## Success Criteria
+
+✅ **Standalone Mode**: Widget loads with defaults, shows standalone notice
+
+✅ **Props Flow**: Tool call → resource URI → decoded props → widget renders correctly
+
+✅ **Theme Support**: Widget adapts to light/dark theme
+
+✅ **Interactive Features**: Buttons work, actions trigger (in MCP-enabled mode)
+
+✅ **Error Handling**: Graceful fallbacks when `window.openai` unavailable
+
+✅ **Multiple Instances**: Can load same widget multiple times with different props
+
+---
+
+## Next Steps
+
+- **Add Tests**: Write integration tests using the patterns above
+- **Deploy Widget**: Build and deploy React app to Vercel/Netlify
+- **Update Server Config**: Point `url` in `uiResource()` to deployed URL
+- **Test in Claude Desktop**: Configure as MCP server and test end-to-end

--- a/examples/react-widget/package.json
+++ b/examples/react-widget/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@mcp-lite/example-react-widget",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "dev:widget": "cd widget-app && bun run dev",
+    "test:manual": "bun run scripts/test-manual.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.6.14",
+    "mcp-lite": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/react-widget/scripts/test-manual.ts
+++ b/examples/react-widget/scripts/test-manual.ts
@@ -122,7 +122,7 @@ function verifyPropsInjection(
   }
 
   try {
-    const injectedProps = JSON.parse(match[1].replace(/\s/g, ""));
+    const injectedProps = JSON.parse(match[1]?.replace(/\s/g, "") ?? "{}");
     const expected = JSON.stringify(expectedProps);
     const actual = JSON.stringify(injectedProps);
 

--- a/examples/react-widget/scripts/test-manual.ts
+++ b/examples/react-widget/scripts/test-manual.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+
+/**
+ * Manual test script for mcp-lite React widgets
+ *
+ * This script tests the widget flow:
+ * 1. Initialize MCP session
+ * 2. Call widget tools with test data
+ * 3. Read widget resources
+ * 4. Verify props injection
+ *
+ * Usage:
+ *   bun run scripts/test-manual.ts
+ */
+
+const MCP_URL = "http://localhost:3002/mcp";
+const PROTOCOL_VERSION = "2025-06-18";
+
+interface JsonRpcRequest {
+  jsonrpc: string;
+  id: string;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: string;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+let sessionId: string | null = null;
+
+async function mcpRequest(
+  method: string,
+  params?: unknown,
+): Promise<JsonRpcResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "MCP-Protocol-Version": PROTOCOL_VERSION,
+  };
+
+  if (sessionId) {
+    headers["MCP-Session-Id"] = sessionId;
+  }
+
+  const request: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: Math.random().toString(36).slice(2),
+    method,
+    params,
+  };
+
+  console.log(`\n→ ${method}`);
+  if (params) {
+    console.log(
+      `  Params: ${JSON.stringify(params, null, 2).split("\n").join("\n  ")}`,
+    );
+  }
+
+  const response = await fetch(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(request),
+  });
+
+  // Capture session ID from first response
+  if (!sessionId) {
+    const sid = response.headers.get("MCP-Session-Id");
+    if (sid) {
+      sessionId = sid;
+      console.log(`  Session ID: ${sessionId}`);
+    }
+  }
+
+  const json = (await response.json()) as JsonRpcResponse;
+
+  if (json.error) {
+    console.error(`  ✗ Error: ${json.error.message}`);
+    if (json.error.data) {
+      console.error(`    Data: ${JSON.stringify(json.error.data)}`);
+    }
+    return json;
+  }
+
+  console.log(`  ✓ Success`);
+  return json;
+}
+
+function extractResourceUri(
+  result: Record<string, unknown>,
+): string | undefined {
+  const content = result.content as Array<{ type: string; uri?: string }>;
+  return content?.find((c) => c.type === "resource_link")?.uri;
+}
+
+function verifyPropsInjection(
+  html: string,
+  expectedProps: Record<string, unknown>,
+): boolean {
+  // Check if window.openai.toolInput is present
+  if (!html.includes("window.openai")) {
+    console.error("  ✗ Missing window.openai injection");
+    return false;
+  }
+
+  if (!html.includes("toolInput")) {
+    console.error("  ✗ Missing toolInput property");
+    return false;
+  }
+
+  // Try to extract the injected props
+  const match = html.match(/window\.openai\.toolInput\s*=\s*({[^}]+})/);
+  if (!match) {
+    console.error("  ✗ Could not extract toolInput from HTML");
+    return false;
+  }
+
+  try {
+    const injectedProps = JSON.parse(match[1].replace(/\s/g, ""));
+    const expected = JSON.stringify(expectedProps);
+    const actual = JSON.stringify(injectedProps);
+
+    if (expected === actual) {
+      console.log(`  ✓ Props correctly injected: ${actual}`);
+      return true;
+    }
+
+    console.error(`  ✗ Props mismatch`);
+    console.error(`    Expected: ${expected}`);
+    console.error(`    Actual: ${actual}`);
+    return false;
+  } catch (error) {
+    console.error(`  ✗ Failed to parse injected props: ${error}`);
+    return false;
+  }
+}
+
+async function testWidgetFlow(
+  widgetName: string,
+  args: Record<string, unknown>,
+  description: string,
+) {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`TEST: ${description}`);
+  console.log("=".repeat(60));
+
+  // Step 1: Call the tool
+  console.log(`\nStep 1: Call tool '${widgetName}'`);
+  const toolResult = await mcpRequest("tools/call", {
+    name: widgetName,
+    arguments: args,
+  });
+
+  if (toolResult.error) {
+    console.error(`\n✗ Test failed at tool call\n`);
+    return false;
+  }
+
+  // Step 2: Extract resource URI
+  const result = toolResult.result as Record<string, unknown>;
+  const uri = extractResourceUri(result);
+
+  if (!uri) {
+    console.error(`\n✗ No resource URI in tool response`);
+    console.error(`  Result: ${JSON.stringify(result, null, 2)}`);
+    return false;
+  }
+
+  console.log(`\n  Resource URI: ${uri}`);
+
+  // Step 3: Read the resource
+  console.log(`\nStep 2: Read resource`);
+  const resourceResult = await mcpRequest("resources/read", { uri });
+
+  if (resourceResult.error) {
+    console.error(`\n✗ Test failed at resource read\n`);
+    return false;
+  }
+
+  // Step 4: Verify props injection
+  console.log(`\nStep 3: Verify props injection`);
+  const resourceData = resourceResult.result as {
+    contents: Array<{ text: string }>;
+  };
+  const html = resourceData.contents[0]?.text;
+
+  if (!html) {
+    console.error(`\n✗ No HTML content in resource`);
+    return false;
+  }
+
+  const propsOk = verifyPropsInjection(html, args);
+
+  console.log(`\n${propsOk ? "✓ Test PASSED" : "✗ Test FAILED"}\n`);
+  return propsOk;
+}
+
+async function runTests() {
+  console.log("MCP-LITE REACT WIDGET MANUAL TESTS");
+  console.log("==================================");
+  console.log(`Server: ${MCP_URL}\n`);
+
+  // Initialize session
+  console.log("Initializing MCP session...");
+  const initResult = await mcpRequest("initialize", {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: {
+      name: "test-script",
+      version: "1.0.0",
+    },
+  });
+
+  if (initResult.error) {
+    console.error("\n✗ Failed to initialize session");
+    console.error("Make sure the MCP server is running:");
+    console.error("  cd examples/react-widget && bun run dev\n");
+    process.exit(1);
+  }
+
+  // List available tools
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("Available Tools");
+  console.log("=".repeat(60));
+
+  const toolsResult = await mcpRequest("tools/list");
+  if (!toolsResult.error) {
+    const tools = (toolsResult.result as { tools: Array<{ name: string }> })
+      .tools;
+    console.log(`\nFound ${tools.length} tools:`);
+    tools.forEach((tool) => {
+      console.log(`  • ${tool.name}`);
+    });
+  }
+
+  // Run widget tests
+  const tests = [
+    {
+      name: "inline-counter",
+      args: { initialCount: 42 },
+      description: "Inline Counter with initialCount=42",
+    },
+    {
+      name: "inline-counter",
+      args: { initialCount: 0 },
+      description: "Inline Counter with initialCount=0",
+    },
+    {
+      name: "weather-widget",
+      args: {
+        city: "Tokyo",
+        temperature: 28,
+        weather: "sunny",
+      },
+      description: "Weather Widget for Tokyo (sunny, 28°C)",
+    },
+    {
+      name: "weather-widget",
+      args: {
+        city: "London",
+        temperature: 12,
+        weather: "rain",
+      },
+      description: "Weather Widget for London (rain, 12°C)",
+    },
+    {
+      name: "task-list",
+      args: {
+        tasks: ["Buy groceries", "Walk the dog", "Finish project"],
+      },
+      description: "Task List with 3 tasks",
+    },
+    {
+      name: "task-list",
+      args: {
+        tasks: [],
+      },
+      description: "Task List with empty array",
+    },
+  ];
+
+  const results = [];
+  for (const test of tests) {
+    const passed = await testWidgetFlow(test.name, test.args, test.description);
+    results.push({ ...test, passed });
+  }
+
+  // Summary
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("TEST SUMMARY");
+  console.log(`${"=".repeat(60)}\n`);
+
+  const passed = results.filter((r) => r.passed).length;
+  const total = results.length;
+
+  results.forEach((r) => {
+    console.log(`${r.passed ? "✓" : "✗"} ${r.description}`);
+  });
+
+  console.log(`\n${passed}/${total} tests passed\n`);
+
+  if (passed < total) {
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch((error) => {
+  console.error("\n✗ Fatal error:");
+  console.error(error);
+  console.error("\nMake sure the MCP server is running:");
+  console.error("  cd examples/react-widget && bun run dev\n");
+  process.exit(1);
+});
+
+export {};

--- a/examples/react-widget/src/index.ts
+++ b/examples/react-widget/src/index.ts
@@ -1,0 +1,234 @@
+import { Hono } from "hono";
+import { McpServer, StreamableHttpTransport } from "mcp-lite";
+
+const mcp = new McpServer({
+  name: "react-widget-example",
+  version: "1.0.0",
+});
+
+// Example 1: Inline HTML widget with useWidget (no React build needed)
+mcp.uiResource({
+  type: "rawHtml",
+  name: "inline-counter",
+  title: "Inline Counter",
+  description: "Simple counter widget using vanilla JS + useWidget pattern",
+  inputSchema: {
+    type: "object",
+    properties: {
+      initialCount: { type: "number", description: "Initial counter value" },
+    },
+  },
+  htmlContent: `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <style>
+          body { font-family: system-ui; padding: 20px; }
+          .counter { text-align: center; }
+          .count { font-size: 48px; font-weight: bold; margin: 20px 0; }
+          button { padding: 10px 20px; margin: 5px; border-radius: 8px; border: 1px solid #ccc; cursor: pointer; }
+          button:hover { background: #f0f0f0; }
+          [data-theme="dark"] { background: #1a1a1a; color: white; }
+          [data-theme="dark"] button { background: #333; color: white; border-color: #555; }
+          [data-theme="dark"] button:hover { background: #444; }
+        </style>
+      </head>
+      <body>
+        <div class="counter">
+          <h1>Counter Widget</h1>
+          <div class="count" id="count">0</div>
+          <button onclick="increment()">+1</button>
+          <button onclick="decrement()">-1</button>
+          <button onclick="reset()">Reset</button>
+        </div>
+        
+        <script>
+          // Mimic useWidget hook behavior
+          const props = window.openai?.toolInput || { initialCount: 0 };
+          const theme = window.openai?.theme || 'light';
+          
+          document.body.setAttribute('data-theme', theme);
+          
+          let count = props.initialCount || 0;
+          const countEl = document.getElementById('count');
+          
+          function updateCount() {
+            countEl.textContent = count;
+          }
+          
+          function increment() {
+            count++;
+            updateCount();
+          }
+          
+          function decrement() {
+            count--;
+            updateCount();
+          }
+          
+          function reset() {
+            count = props.initialCount || 0;
+            updateCount();
+          }
+          
+          updateCount();
+        </script>
+      </body>
+    </html>
+  `,
+});
+
+// Example 2: External React widget (you'd build this separately with Vite/Next.js)
+// In a real setup, you'd:
+// 1. Create a React app with @mcp-lite/react
+// 2. Build it and deploy to a static host
+// 3. Point the URL to your deployed app
+
+mcp.uiResource({
+  type: "externalUrl",
+  name: "weather-widget",
+  title: "Weather Widget",
+  description: "Display weather information (React)",
+  // In production, this would be your deployed React app URL
+  // For now, using a placeholder that shows the pattern
+  url: "https://your-react-app.vercel.app/weather",
+  inputSchema: {
+    type: "object",
+    properties: {
+      city: { type: "string", description: "City name" },
+      temperature: { type: "number", description: "Temperature in Celsius" },
+      weather: {
+        type: "string",
+        enum: ["sunny", "rain", "snow", "cloudy"],
+        description: "Weather condition",
+      },
+    },
+    required: ["city", "temperature", "weather"],
+  },
+  size: ["600px", "400px"],
+});
+
+// Example 3: Remote DOM with script (lightweight interactivity)
+mcp.uiResource({
+  type: "remoteDom",
+  name: "task-list",
+  title: "Task List",
+  description: "Interactive task list widget",
+  inputSchema: {
+    type: "object",
+    properties: {
+      tasks: {
+        type: "array",
+        items: { type: "string" },
+        description: "List of tasks",
+      },
+    },
+  },
+  script: `
+    const props = window.openai?.toolInput || { tasks: [] };
+    const theme = window.openai?.theme || 'light';
+    
+    const isDark = theme === 'dark';
+    
+    // Create title
+    const h1 = document.createElement('h1');
+    h1.textContent = 'My Tasks';
+    h1.style.margin = '0 0 16px 0';
+    h1.style.fontSize = '24px';
+    h1.style.color = isDark ? '#fff' : '#000';
+    root.appendChild(h1);
+    
+    // Create task list
+    const ul = document.createElement('ul');
+    ul.style.listStyle = 'none';
+    ul.style.padding = '0';
+    
+    (props.tasks || []).forEach((task, index) => {
+      const li = document.createElement('li');
+      li.style.padding = '12px';
+      li.style.margin = '8px 0';
+      li.style.background = isDark ? '#2a2a2a' : '#f5f5f5';
+      li.style.borderRadius = '8px';
+      li.style.display = 'flex';
+      li.style.alignItems = 'center';
+      li.style.gap = '8px';
+      li.style.color = isDark ? '#fff' : '#000';
+      
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = 'task-' + index;
+      checkbox.style.width = '20px';
+      checkbox.style.height = '20px';
+      
+      const label = document.createElement('label');
+      label.htmlFor = 'task-' + index;
+      label.textContent = task;
+      label.style.flex = '1';
+      label.style.cursor = 'pointer';
+      
+      checkbox.addEventListener('change', () => {
+        label.style.textDecoration = checkbox.checked ? 'line-through' : 'none';
+        label.style.opacity = checkbox.checked ? '0.6' : '1';
+      });
+      
+      li.appendChild(checkbox);
+      li.appendChild(label);
+      ul.appendChild(li);
+    });
+    
+    root.appendChild(ul);
+    
+    // Add a hint about no tasks
+    if (!props.tasks || props.tasks.length === 0) {
+      const hint = document.createElement('p');
+      hint.textContent = 'No tasks yet! Add some in the chat.';
+      hint.style.color = isDark ? '#888' : '#666';
+      hint.style.textAlign = 'center';
+      hint.style.marginTop = '20px';
+      root.appendChild(hint);
+    }
+  `,
+  size: ["500px", "400px"],
+});
+
+// Create HTTP transport and bind server
+const transport = new StreamableHttpTransport();
+const httpHandler = transport.bind(mcp);
+
+// Create Hono app
+const app = new Hono();
+
+app.all("/mcp", async (c) => {
+  const response = await httpHandler(c.req.raw);
+  return response;
+});
+
+app.get("/health", (c) => {
+  return c.json({ status: "ok", server: "react-widget-example" });
+});
+
+const port = 3002;
+
+export default app;
+
+if (import.meta.main) {
+  console.log(`🚀 MCP Server with React widgets running on port ${port}`);
+  console.log(`   Health: http://localhost:${port}/health`);
+  console.log(`   MCP endpoint: http://localhost:${port}/mcp`);
+  console.log();
+  console.log(`📦 Registered widgets:`);
+  console.log(`   - inline-counter (rawHtml with useWidget pattern)`);
+  console.log(`   - weather-widget (externalUrl - React app)`);
+  console.log(`   - task-list (remoteDom with script)`);
+  console.log();
+  console.log(`💡 To test with a real React widget:`);
+  console.log(`   1. Create a React app with @mcp-lite/react`);
+  console.log(`   2. Build and deploy to Vercel/Netlify/etc`);
+  console.log(`   3. Update the weather-widget URL above`);
+
+  Bun.serve({
+    port,
+    fetch: app.fetch,
+  });
+}

--- a/examples/react-widget/tsconfig.json
+++ b/examples/react-widget/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/react-widget/tsconfig.json
+++ b/examples/react-widget/tsconfig.json
@@ -1,7 +1,29 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["bun-types"]
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["node_modules", "dist", "widget-app", "**/*.test.ts"]
 }

--- a/examples/react-widget/widget-app/index.html
+++ b/examples/react-widget/widget-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weather Widget</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-widget/widget-app/package.json
+++ b/examples/react-widget/widget-app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "weather-widget-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mcp-lite/react": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/examples/react-widget/widget-app/src/WeatherWidget.tsx
+++ b/examples/react-widget/widget-app/src/WeatherWidget.tsx
@@ -1,0 +1,160 @@
+import { useWidget } from "@mcp-lite/react";
+import { useState } from "react";
+
+interface WeatherProps {
+  city: string;
+  temperature: number;
+  weather: "sunny" | "rain" | "snow" | "cloudy";
+}
+
+export default function WeatherWidget() {
+  const { props, theme, callTool, sendFollowUpMessage, isAvailable } =
+    useWidget<WeatherProps>({
+      city: "Unknown",
+      temperature: 0,
+      weather: "cloudy",
+    });
+
+  const [loading, setLoading] = useState(false);
+  const [forecast, setForecast] = useState<string | null>(null);
+
+  const getWeatherIcon = (weatherType: string) => {
+    switch (weatherType?.toLowerCase()) {
+      case "sunny":
+        return "☀️";
+      case "rain":
+        return "🌧️";
+      case "snow":
+        return "❄️";
+      case "cloudy":
+        return "☁️";
+      default:
+        return "🌤️";
+    }
+  };
+
+  const getWeatherColor = (weatherType: string) => {
+    switch (weatherType?.toLowerCase()) {
+      case "sunny":
+        return "from-yellow-400 to-orange-500";
+      case "rain":
+        return "from-blue-400 to-blue-600";
+      case "snow":
+        return "from-blue-100 to-blue-300";
+      case "cloudy":
+        return "from-gray-400 to-gray-600";
+      default:
+        return "from-gray-300 to-gray-500";
+    }
+  };
+
+  const handleFetchForecast = async () => {
+    if (!isAvailable) {
+      alert("MCP APIs not available in standalone mode");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await callTool("get-forecast", {
+        city: props.city,
+        days: 7,
+      });
+      setForecast(
+        result.content.find((c) => c.type === "text")?.text ||
+          "No forecast available",
+      );
+    } catch (error) {
+      console.error("Failed to fetch forecast:", error);
+      setForecast("Error fetching forecast");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAskMore = () => {
+    if (!isAvailable) {
+      alert("MCP APIs not available in standalone mode");
+      return;
+    }
+    sendFollowUpMessage(`Tell me more about the weather in ${props.city}`);
+  };
+
+  const bgColor = theme === "dark" ? "bg-gray-900" : "bg-white";
+  const textColor = theme === "dark" ? "text-gray-100" : "text-gray-800";
+  const cardBg = theme === "dark" ? "bg-gray-800" : "bg-gray-50";
+
+  return (
+    <div className={`min-h-screen ${bgColor} ${textColor} p-6`}>
+      <div className="max-w-sm mx-auto">
+        {/* Weather Card */}
+        <div className={`${cardBg} rounded-xl shadow-lg overflow-hidden`}>
+          {/* Weather Icon Header */}
+          <div
+            className={`h-32 bg-gradient-to-br ${getWeatherColor(props.weather)} flex items-center justify-center`}
+          >
+            <div className="text-6xl">{getWeatherIcon(props.weather)}</div>
+          </div>
+
+          {/* Weather Info */}
+          <div className="p-6">
+            <div className="text-center">
+              <h2 className="text-2xl font-bold mb-2">{props.city}</h2>
+              <div className="flex items-center justify-center space-x-4">
+                <span className="text-4xl font-light">
+                  {props.temperature}°
+                </span>
+                <div className="text-right">
+                  <p className="text-lg font-medium capitalize">
+                    {props.weather}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        {isAvailable && (
+          <div className="mt-4 space-y-2">
+            <button
+              type="button"
+              onClick={handleFetchForecast}
+              disabled={loading}
+              className="w-full px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? "Loading..." : "Get 7-Day Forecast"}
+            </button>
+
+            <button
+              type="button"
+              onClick={handleAskMore}
+              className="w-full px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+            >
+              Ask for More Info
+            </button>
+          </div>
+        )}
+
+        {/* Forecast Display */}
+        {forecast && (
+          <div className={`mt-4 p-4 ${cardBg} rounded-lg`}>
+            <h3 className="font-semibold mb-2">7-Day Forecast:</h3>
+            <p className="text-sm">{forecast}</p>
+          </div>
+        )}
+
+        {/* Standalone Mode Notice */}
+        {!isAvailable && (
+          <div className="mt-4 p-4 bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded-lg text-sm">
+            <p className="font-semibold">Standalone Mode</p>
+            <p className="mt-1">
+              This widget is running in standalone mode. Deploy it and register
+              with an MCP server to enable interactive features.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/react-widget/widget-app/src/index.css
+++ b/examples/react-widget/widget-app/src/index.css
@@ -1,0 +1,36 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+}

--- a/examples/react-widget/widget-app/src/main.tsx
+++ b/examples/react-widget/widget-app/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import WeatherWidget from "./WeatherWidget";
+import "./index.css";
+
+const rootElement = document.getElementById("root");
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <WeatherWidget />
+    </React.StrictMode>,
+  );
+}

--- a/examples/react-widget/widget-app/tsconfig.json
+++ b/examples/react-widget/widget-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/react-widget/widget-app/vite.config.ts
+++ b/examples/react-widget/widget-app/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "packages/*",
     "playground",
-    "examples/*"
+    "examples/*",
+    "examples/*/widget-app"
   ],
   "repository": {
     "type": "git",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,220 @@
+# @mcp-lite/react
+
+React hooks for building UI widgets with mcp-lite's `uiResource()` system.
+
+## Installation
+
+```bash
+npm install @mcp-lite/react react
+```
+
+## Quick Start
+
+### 1. Create a React Widget
+
+```tsx
+// MyWidget.tsx
+import { useWidget } from "@mcp-lite/react";
+
+interface MyProps {
+  city: string;
+  temperature: number;
+}
+
+export default function WeatherWidget() {
+  const { props, theme } = useWidget<MyProps>();
+
+  return (
+    <div data-theme={theme}>
+      <h1>{props.city}</h1>
+      <p>{props.temperature}°C</p>
+    </div>
+  );
+}
+```
+
+### 2. Register with uiResource()
+
+Use `type: "externalUrl"` to serve your built React app:
+
+```ts
+import { McpServer } from "mcp-lite";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+
+server.uiResource({
+  type: "externalUrl",
+  name: "weather-widget",
+  title: "Weather Widget",
+  description: "Display weather information",
+  url: "https://your-widget-host.com/weather", // Your React app URL
+  inputSchema: {
+    type: "object",
+    properties: {
+      city: { type: "string" },
+      temperature: { type: "number" },
+    },
+    required: ["city", "temperature"],
+  },
+  size: ["600px", "400px"],
+});
+```
+
+### 3. How Props Flow
+
+1. **LLM** calls the tool `weather-widget` with args: `{ city: "Paris", temperature: 22 }`
+2. **MCP Server** (mcp-lite) returns a `resource_link` to the widget HTML with props encoded in the query string
+3. **Client** (ChatGPT/Apps SDK) loads the widget HTML
+4. **Server** injects `window.openai.toolInput = { city: "Paris", temperature: 22 }`
+5. **useWidget hook** reads from `window.openai.toolInput` and provides it as `props`
+6. **Your React component** renders with the props
+
+## API Reference
+
+### `useWidget<TProps, TState>(defaultProps?)`
+
+Main hook for accessing widget context and APIs.
+
+```tsx
+const {
+  props,        // Tool input parameters
+  theme,        // "light" | "dark"
+  displayMode,  // "inline" | "fullscreen" | "pip"
+  locale,       // User locale (e.g., "en")
+  state,        // Persistent widget state
+  setState,     // Update widget state
+  
+  // Actions
+  callTool,            // Call other MCP tools
+  sendFollowUpMessage, // Send message to chat
+  openExternal,        // Open external URL
+  requestDisplayMode,  // Request display mode change
+  
+  isAvailable,  // Whether Apps SDK APIs are available
+} = useWidget<MyProps, MyState>();
+```
+
+### `useWidgetProps<TProps>(defaultProps?)`
+
+Shorthand for just getting props:
+
+```tsx
+const props = useWidgetProps<{ city: string }>();
+```
+
+### `useWidgetTheme()`
+
+Get current theme:
+
+```tsx
+const theme = useWidgetTheme();
+const bgColor = theme === "dark" ? "bg-gray-900" : "bg-white";
+```
+
+### `useWidgetState<TState>(defaultState?)`
+
+Persistent widget state:
+
+```tsx
+const [favorites, setFavorites] = useWidgetState<string[]>([]);
+
+await setFavorites([...favorites, "Paris"]);
+```
+
+## Complete Example
+
+```tsx
+import { useWidget } from "@mcp-lite/react";
+import { useState } from "react";
+
+interface WeatherProps {
+  city: string;
+  weather: "sunny" | "rain" | "snow" | "cloudy";
+  temperature: number;
+}
+
+export default function WeatherWidget() {
+  const { props, theme, callTool, sendFollowUpMessage } = useWidget<WeatherProps>();
+  const [loading, setLoading] = useState(false);
+
+  const fetchForecast = async () => {
+    setLoading(true);
+    try {
+      const result = await callTool("get-forecast", {
+        city: props.city,
+        days: 7,
+      });
+      console.log("Forecast:", result);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const askForMore = () => {
+    sendFollowUpMessage(`Tell me more about weather in ${props.city}`);
+  };
+
+  const bgColor = theme === "dark" ? "bg-gray-900" : "bg-white";
+  const textColor = theme === "dark" ? "text-white" : "text-gray-900";
+
+  return (
+    <div className={`p-6 rounded-lg ${bgColor} ${textColor}`}>
+      <h1 className="text-2xl font-bold mb-2">{props.city}</h1>
+      <p className="text-4xl mb-4">{props.temperature}°C</p>
+      <p className="capitalize mb-4">{props.weather}</p>
+      
+      <button
+        onClick={fetchForecast}
+        disabled={loading}
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        {loading ? "Loading..." : "Get 7-day Forecast"}
+      </button>
+      
+      <button
+        onClick={askForMore}
+        className="ml-2 px-4 py-2 bg-gray-500 text-white rounded"
+      >
+        Ask for More Info
+      </button>
+    </div>
+  );
+}
+```
+
+## TypeScript Support
+
+Full type inference for props:
+
+```tsx
+import { z } from "zod";
+
+const WeatherSchema = z.object({
+  city: z.string(),
+  temperature: z.number(),
+  weather: z.enum(["sunny", "rain", "snow", "cloudy"]),
+});
+
+type WeatherProps = z.infer<typeof WeatherSchema>;
+
+// Props are fully typed
+const { props } = useWidget<WeatherProps>();
+props.city;        // ✅ string
+props.temperature; // ✅ number
+props.weather;     // ✅ "sunny" | "rain" | "snow" | "cloudy"
+```
+
+## Differences from mcp-use
+
+This is a minimal, standalone React hook package for mcp-lite. Key differences:
+
+- **No auto-registration**: You register widgets explicitly with `server.uiResource()`
+- **No Vite dev server**: You build and host your React app separately
+- **Simpler API surface**: Focuses on the core `window.openai` bridge
+- **Framework agnostic server**: Works with any build tool and hosting setup
+
+If you need auto-registration, HMR, and a full development pipeline, consider using [mcp-use](https://github.com/mcp-use/mcp-use).
+
+## License
+
+MIT

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@mcp-lite/react",
+  "version": "0.1.0",
+  "description": "React hooks for mcp-lite UI widgets",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "react",
+    "hooks",
+    "widgets"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "react": "^18.3.1",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,13 @@
+export type {
+  CallToolResponse,
+  DisplayMode,
+  Theme,
+  UseWidgetResult,
+  WindowOpenAI,
+} from "./types.js";
+export {
+  useWidget,
+  useWidgetProps,
+  useWidgetState,
+  useWidgetTheme,
+} from "./useWidget.js";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Type definitions for OpenAI Apps SDK window.openai API
+ * Minimal subset for mcp-lite compatibility
+ */
+
+export type Theme = "light" | "dark";
+export type DisplayMode = "pip" | "inline" | "fullscreen";
+
+export interface CallToolResponse {
+  content: Array<{
+    type: string;
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * OpenAI Apps SDK global API surface
+ */
+export interface WindowOpenAI<TState = unknown> {
+  // Layout & theme globals
+  theme?: Theme;
+  displayMode?: DisplayMode;
+  locale?: string;
+
+  // Input from tool invocation
+  toolInput?: unknown;
+
+  // Output from tool if available
+  toolOutput?: unknown;
+
+  // Persistent widget state
+  widgetState?: TState;
+
+  // API methods
+  callTool?: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<CallToolResponse>;
+  sendFollowUpMessage?: (args: { prompt: string }) => Promise<void>;
+  openExternal?: (args: { href: string }) => void;
+  requestDisplayMode?: (args: {
+    mode: DisplayMode;
+  }) => Promise<{ mode: DisplayMode }>;
+  setWidgetState?: (state: TState) => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    // biome-ignore lint/suspicious/noExplicitAny: Generic state type for window.openai
+    openai?: WindowOpenAI<any>;
+  }
+}
+
+/**
+ * Result type for the useWidget hook
+ */
+export interface UseWidgetResult<
+  TProps = Record<string, unknown>,
+  TState = unknown,
+> {
+  // Props from tool invocation
+  props: TProps;
+
+  // Layout and theme
+  theme: Theme;
+  displayMode: DisplayMode;
+  locale: string;
+
+  // Widget state
+  state: TState | null;
+  setState: (
+    state: TState | ((prev: TState | null) => TState),
+  ) => Promise<void>;
+
+  // Actions
+  callTool: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<CallToolResponse>;
+  sendFollowUpMessage: (prompt: string) => Promise<void>;
+  openExternal: (href: string) => void;
+  requestDisplayMode: (mode: DisplayMode) => Promise<{ mode: DisplayMode }>;
+
+  // Availability
+  isAvailable: boolean;
+}

--- a/packages/react/src/useWidget.ts
+++ b/packages/react/src/useWidget.ts
@@ -1,0 +1,258 @@
+/**
+ * React hook for mcp-lite UI widgets
+ * Connects to window.openai.toolInput injected by server
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import type {
+  CallToolResponse,
+  DisplayMode,
+  Theme,
+  UseWidgetResult,
+} from "./types.js";
+
+// Event type for window.openai global changes
+const SET_GLOBALS_EVENT_TYPE = "openai:set_globals";
+
+/**
+ * Hook to subscribe to a single value from window.openai globals
+ * Uses React 18's useSyncExternalStore for efficient subscriptions
+ */
+function useOpenAiGlobal<K extends keyof NonNullable<typeof window.openai>>(
+  key: K,
+): NonNullable<typeof window.openai>[K] | undefined {
+  return useSyncExternalStore(
+    (onChange) => {
+      const handleSetGlobal = (event: Event) => {
+        const customEvent = event as CustomEvent<{
+          globals: Partial<NonNullable<typeof window.openai>>;
+        }>;
+        const value = customEvent.detail?.globals[key];
+        if (value !== undefined) {
+          onChange();
+        }
+      };
+
+      if (typeof window !== "undefined") {
+        window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
+      }
+
+      return () => {
+        if (typeof window !== "undefined") {
+          window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
+        }
+      };
+    },
+    () =>
+      typeof window !== "undefined" && window.openai
+        ? window.openai[key]
+        : undefined,
+  );
+}
+
+/**
+ * React hook for building widgets with mcp-lite uiResource()
+ *
+ * Automatically reads props from window.openai.toolInput (injected by the server)
+ * and provides APIs for interacting with the MCP client.
+ *
+ * @example Basic usage
+ * ```tsx
+ * import { useWidget } from "@mcp-lite/react";
+ *
+ * interface MyProps {
+ *   city: string;
+ *   temperature: number;
+ * }
+ *
+ * export default function WeatherWidget() {
+ *   const { props, theme } = useWidget<MyProps>();
+ *
+ *   return (
+ *     <div data-theme={theme}>
+ *       <h1>{props.city}</h1>
+ *       <p>{props.temperature}°C</p>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @example With default props
+ * ```tsx
+ * const { props } = useWidget<MyProps>({ city: "Unknown", temperature: 0 });
+ * ```
+ */
+export function useWidget<TProps = Record<string, unknown>, TState = unknown>(
+  defaultProps?: TProps,
+): UseWidgetResult<TProps, TState> {
+  // Check if window.openai is available
+  const isAvailable = typeof window !== "undefined" && !!window.openai;
+
+  // Subscribe to reactive globals using useSyncExternalStore
+  const toolInput = useOpenAiGlobal("toolInput") as TProps | undefined;
+  const widgetState = useOpenAiGlobal("widgetState") as TState | undefined;
+  const theme = useOpenAiGlobal("theme") as Theme | undefined;
+  const displayMode = useOpenAiGlobal("displayMode") as DisplayMode | undefined;
+  const locale = useOpenAiGlobal("locale") as string | undefined;
+
+  // Local state management with sync from window.openai
+  const [localState, setLocalState] = useState<TState | null>(
+    widgetState ?? null,
+  );
+
+  // Sync widget state from window.openai when it changes
+  useEffect(() => {
+    if (widgetState !== undefined) {
+      setLocalState(widgetState);
+    }
+  }, [widgetState]);
+
+  // Stable API methods
+  const callTool = useCallback(
+    async (
+      name: string,
+      args: Record<string, unknown>,
+    ): Promise<CallToolResponse> => {
+      if (typeof window === "undefined" || !window.openai?.callTool) {
+        throw new Error("window.openai.callTool is not available");
+      }
+      return window.openai.callTool(name, args);
+    },
+    [],
+  );
+
+  const sendFollowUpMessage = useCallback(
+    async (prompt: string): Promise<void> => {
+      if (
+        typeof window === "undefined" ||
+        !window.openai?.sendFollowUpMessage
+      ) {
+        throw new Error("window.openai.sendFollowUpMessage is not available");
+      }
+      return window.openai.sendFollowUpMessage({ prompt });
+    },
+    [],
+  );
+
+  const openExternal = useCallback((href: string): void => {
+    if (typeof window === "undefined" || !window.openai?.openExternal) {
+      throw new Error("window.openai.openExternal is not available");
+    }
+    window.openai.openExternal({ href });
+  }, []);
+
+  const requestDisplayMode = useCallback(
+    async (mode: DisplayMode): Promise<{ mode: DisplayMode }> => {
+      if (typeof window === "undefined" || !window.openai?.requestDisplayMode) {
+        throw new Error("window.openai.requestDisplayMode is not available");
+      }
+      return window.openai.requestDisplayMode({ mode });
+    },
+    [],
+  );
+
+  const setState = useCallback(
+    async (
+      stateOrUpdater: TState | ((prevState: TState | null) => TState),
+    ): Promise<void> => {
+      const newState =
+        typeof stateOrUpdater === "function"
+          ? (stateOrUpdater as (prevState: TState | null) => TState)(localState)
+          : stateOrUpdater;
+
+      if (typeof window === "undefined" || !window.openai?.setWidgetState) {
+        // Fallback: just update local state if API not available
+        setLocalState(newState);
+        return;
+      }
+
+      setLocalState(newState);
+      return window.openai.setWidgetState(newState);
+    },
+    [localState],
+  );
+
+  return {
+    // Props from tool invocation (with fallback to defaults)
+    props: (toolInput ?? defaultProps ?? {}) as TProps,
+
+    // Layout and theme (with safe defaults)
+    theme: theme ?? "light",
+    displayMode: displayMode ?? "inline",
+    locale: locale ?? "en",
+
+    // State
+    state: localState,
+    setState,
+
+    // Actions
+    callTool,
+    sendFollowUpMessage,
+    openExternal,
+    requestDisplayMode,
+
+    // Availability
+    isAvailable,
+  };
+}
+
+/**
+ * Hook to get just the widget props (most common use case)
+ *
+ * @example
+ * ```tsx
+ * const props = useWidgetProps<{ city: string }>();
+ * ```
+ */
+export function useWidgetProps<TProps = Record<string, unknown>>(
+  defaultProps?: TProps,
+): TProps {
+  const { props } = useWidget<TProps>(defaultProps);
+  return props;
+}
+
+/**
+ * Hook to get theme value
+ *
+ * @example
+ * ```tsx
+ * const theme = useWidgetTheme();
+ * const bgColor = theme === "dark" ? "bg-gray-900" : "bg-white";
+ * ```
+ */
+export function useWidgetTheme(): Theme {
+  const { theme } = useWidget();
+  return theme;
+}
+
+/**
+ * Hook to get and update widget state
+ *
+ * @example
+ * ```tsx
+ * const [favorites, setFavorites] = useWidgetState<string[]>([]);
+ * ```
+ */
+export function useWidgetState<TState = unknown>(
+  defaultState?: TState,
+): readonly [
+  TState | null,
+  (state: TState | ((prev: TState | null) => TState)) => Promise<void>,
+] {
+  const { state, setState } = useWidget<Record<string, unknown>, TState>();
+
+  // Initialize with default if provided and state is null
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only initialize once on mount
+  useEffect(() => {
+    if (
+      state === null &&
+      defaultState !== undefined &&
+      typeof window !== "undefined" &&
+      window.openai?.setWidgetState
+    ) {
+      setState(defaultState);
+    }
+  }, []); // Only run once on mount
+
+  return [state, setState] as const;
+}

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react",
+
+    // Output settings
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "react"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/playground/minimal-server.ts
+++ b/playground/minimal-server.ts
@@ -49,6 +49,61 @@ mcp.tool("add", {
   }),
 });
 
+// Demonstrate uiResource: a raw HTML card
+mcp.uiResource({
+  type: "rawHtml",
+  name: "welcome-card",
+  title: "Welcome Card",
+  description: "Simple welcome widget rendered as HTML",
+  htmlContent: `
+    <div style="display:flex;align-items:center;justify-content:center;height:100%;">
+      <div style="padding:16px;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 4px 16px rgba(0,0,0,0.06)">
+        <h1 style="margin:0 0 8px 0;font-size:20px;">Welcome!</h1>
+        <p style="margin:0;color:#6b7280;">This widget is served by mcp-lite uiResource()</p>
+      </div>
+    </div>
+  `,
+});
+
+// Demonstrate uiResource: a remote DOM script widget
+mcp.uiResource({
+  type: "remoteDom",
+  name: "quick-poll",
+  title: "Quick Poll",
+  description: "Interactive buttons rendered via script",
+  inputSchema: {
+    type: "object",
+    properties: {
+      question: { type: "string", description: "Poll question" },
+    },
+    required: ["question"],
+  },
+  script: `
+    const h2 = document.createElement('h2');
+    h2.textContent = (window.openai?.toolInput?.question ?? 'Do you like this demo?');
+    h2.style.margin = '12px 0';
+    h2.style.fontSize = '18px';
+    root.appendChild(h2);
+    const wrap = document.createElement('div');
+    wrap.style.display = 'flex';
+    wrap.style.gap = '8px';
+    const mkBtn = (label) => {
+      const b = document.createElement('button');
+      b.textContent = label;
+      b.style.padding = '8px 12px';
+      b.style.border = '1px solid #e5e7eb';
+      b.style.borderRadius = '8px';
+      b.style.cursor = 'pointer';
+      b.onclick = () => { b.textContent = label + ' ✓'; };
+      return b;
+    };
+    wrap.appendChild(mkBtn('Yes'));
+    wrap.appendChild(mkBtn('No'));
+    root.appendChild(wrap);
+  `,
+  size: ["500px", "220px"],
+});
+
 // Create HTTP transport in stateless mode (no session adapter)
 const transport = new StreamableHttpTransport();
 const httpHandler = transport.bind(mcp);

--- a/templates/starter-mcp-supabase/supabase/functions/mcp-server/index.ts
+++ b/templates/starter-mcp-supabase/supabase/functions/mcp-server/index.ts
@@ -5,7 +5,6 @@
 // Setup type definitions for built-in Supabase Runtime APIs
 /// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
 
-
 import { Hono } from "hono";
 import { McpServer, StreamableHttpTransport } from "mcp-lite";
 import { z } from "zod";


### PR DESCRIPTION
## Overview

This PR introduces UI widget support to mcp-lite, enabling developers to create interactive widgets similar to [mcp-use](https://github.com/modelcontextprotocol/mcp-use). The implementation adds a new `uiResource()` API that automatically registers widgets as both tools (accepting parameters) and resources (serving the UI).

## What's New

### Core Changes
- **`uiResource()` method** in `McpServer` class for registering interactive widgets
- Support for three widget types:
  - `externalUrl`: Wraps external URLs in an iframe with props injection
  - `rawHtml`: Serves inline HTML directly (useful for simple widgets)
  - `remoteDom`: Executes scripts with a dedicated root element
- Auto-registration as both tool and resource with proper URI scheme (`ui://widget/...`)
- Props flow via URL query parameters and `window.openai.toolInput` injection

### New Package: `@mcp-lite/react`
- `useWidget<TProps, TState>()`: Main hook for widget development
- `useWidgetProps<TProps>()`: Direct access to tool input props
- `useWidgetTheme()`: Theme support (light/dark)
- `useWidgetState<TState>()`: Persistent widget state management
- Full TypeScript support with OpenAI Apps SDK compatibility
- Reactive subscriptions using `useSyncExternalStore`

### Example Implementation
- Complete example in `examples/react-widget/`
- Three widget demos: inline counter, weather widget, and task list
- React widget app with Vite dev server
- Comprehensive testing documentation

## How to Test Manually

### 1. Start the MCP Server

```bash
cd examples/react-widget
bun install
bun run dev
```

The server will start on http://localhost:3002/mcp

### 2. Start the Widget App (for externalUrl testing)

```bash
cd examples/react-widget/widget-app
bun install
bun run dev
```

The widget app will start on http://localhost:5173/

### 3. Run Automated Tests

```bash
cd examples/react-widget
bun run test:manual
```

This will test:
- Tool listing and discovery
- Calling widgets with parameters
- Resource resolution
- Props injection verification
- HTML rendering for all three widget types

### 4. Manual Testing Steps

#### Test Tool Call
```bash
curl -X POST http://localhost:3002/mcp \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "tools/call",
    "params": {
      "name": "weather-widget",
      "arguments": {
        "location": "London",
        "temperature": 15
      }
    }
  }'
```

Expected: Returns a resource link like `ui://widget/weather-widget-{uuid}.html?props=...`

#### Test Resource Retrieval
```bash
# Replace {uuid} with actual UUID from tool call response
curl http://localhost:3002/mcp/resource/ui%3A%2F%2Fwidget%2Fweather-widget-{uuid}.html%3Fprops%3D...
```

Expected: Returns HTML with embedded iframe and props injection

#### Test in Browser
1. Open the resource URL in a browser
2. Verify the widget loads with correct props
3. Check theme support (light/dark)
4. Test interactive features (buttons, API calls)

### 5. Verify React Integration

Open `examples/react-widget/widget-app/src/WeatherWidget.tsx` to see:
- `useWidget()` hook usage
- Props destructuring
- Theme integration
- `callTool()` and `sendFollowUpMessage()` examples
- State management

## Testing Documentation

See `examples/react-widget/TESTING.md` for:
- Detailed test scenarios
- Debugging tips
- Browser-based testing
- End-to-end integration tests

## Breaking Changes

None. This is a new experimental feature that doesn't affect existing APIs.

## Notes

- The `uiResource()` API is marked as experimental
- OpenAI Apps SDK compatibility layer is included for future ChatGPT integration
- All linting and type-checking passes
- Examples use Bun runtime but work with any modern runtime

## Checklist

- [x] Implementation complete
- [x] Examples provided
- [x] Testing guide written
- [x] Linting passes
- [x] Type-checking passes
- [x] Manual testing performed
- [x] Documentation updated

---

Co-authored-by: @Rodriguespn